### PR TITLE
Arn 54 list question groups

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDto.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.assessments.api;
+
+import uk.gov.justice.digital.assessments.jpa.entities.GroupSummaryEntity;
+
+class GroupSummaryDto(
+
+) {
+  companion object {
+    fun from(entity: GroupSummaryEntity): GroupSummaryDto {
+      return GroupSummaryDto()
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDto.kt
@@ -1,13 +1,34 @@
 package uk.gov.justice.digital.assessments.api;
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.assessments.jpa.entities.GroupSummaryEntity;
+import java.util.*
 
 class GroupSummaryDto(
+    @Schema(description = "Group Identifier", example = "<uuid>")
+    val groupId : UUID,
 
+    @Schema(description = "Group Title", example = "Some group!")
+    val title: String,
+
+    @Schema(description = "Total number of groups and questions this group contains", example = "2")
+    val contentCount: Long,
+
+    @Schema(description = "Number of child groups", example = "3")
+    val groupCount: Long,
+
+    @Schema(description = "Number of question in this group", example = "5")
+    val questionCount: Long
 ) {
-  companion object {
-    fun from(entity: GroupSummaryEntity): GroupSummaryDto {
-      return GroupSummaryDto()
+    companion object {
+        fun from(entity: GroupSummaryEntity): GroupSummaryDto {
+            return GroupSummaryDto(
+                    UUID.fromString(entity.groupUuid),
+                    entity.heading,
+                    entity.contentCount,
+                    entity.groupCount,
+                    entity.questionCount
+            )
+        }
     }
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.assessments.api.GroupSummaryDto
 import uk.gov.justice.digital.assessments.api.GroupWithContentsDto
 import uk.gov.justice.digital.assessments.api.QuestionSchemaDto
 import uk.gov.justice.digital.assessments.services.QuestionService
@@ -22,6 +23,14 @@ class QuestionController(val questionService: QuestionService ) {
         ApiResponse(responseCode = "200", description = "OK")])
     fun getQuestionSchema(@PathVariable("questionSchemaId") questionSchemaUUId: UUID): QuestionSchemaDto {
         return questionService.getQuestionSchema(questionSchemaUUId)
+    }
+
+    @RequestMapping(path = ["/questions/list"], method = [RequestMethod.GET])
+    @Operation(description = "Lists available question groups")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "OK")])
+    fun listQuestionGroups(): Collection<GroupSummaryDto> {
+        return questionService.listGroups()
     }
 
     @RequestMapping(path = ["/questions/{groupUuid}"], method = [RequestMethod.GET])

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.assessments.jpa.entities;
+
+interface GroupSummaryEntity {
+    val heading: String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
@@ -1,7 +1,10 @@
 package uk.gov.justice.digital.assessments.jpa.entities;
 
+import java.util.*
+
 interface GroupSummaryEntity {
     val heading: String
+    val contentCount: Long
     val groupCount: Long
     val questionCount: Long
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.assessments.jpa.entities;
 import java.util.*
 
 interface GroupSummaryEntity {
+    val groupUuid: UUID
     val heading: String
     val contentCount: Long
     val groupCount: Long

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
@@ -2,4 +2,6 @@ package uk.gov.justice.digital.assessments.jpa.entities;
 
 interface GroupSummaryEntity {
     val heading: String
+    val groupCount: Long
+    val questionCount: Long
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/GroupSummaryEntity.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.assessments.jpa.entities;
 import java.util.*
 
 interface GroupSummaryEntity {
-    val groupUuid: UUID
+    val groupUuid: String
     val heading: String
     val contentCount: Long
     val groupCount: Long

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
@@ -13,9 +13,12 @@ interface QuestionGroupRepository: JpaRepository<QuestionGroupEntity, String> {
     fun findByGroupGroupUuid(groupId: UUID): Collection<QuestionGroupEntity>?
 
     @Query(value = "select (g.heading\\:\\:varchar) as heading, " +
-                   "-1 as groupCount, " +
-                   "0 as questionCount " +
-                   "from grouping g ",
+                   "count(qg.content_uuid) as contentCount, " +
+                   "count(case when qg.content_type = 'grouping' then qg.content_uuid end) as groupCount, " +
+                   "count(case when qg.content_type = 'question' then qg.content_uuid end) as questionCount, " +
+                   "from question_group qg " +
+                   "left join grouping g on qg.group_uuid = g.group_uuid " +
+                   "group by g.group_uuid, g.heading ",
            nativeQuery = true)
     fun listGroups(): Collection<GroupSummaryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
@@ -12,7 +12,7 @@ interface QuestionGroupRepository: JpaRepository<QuestionGroupEntity, String> {
 
     fun findByGroupGroupUuid(groupId: UUID): Collection<QuestionGroupEntity>?
 
-    @Query(value = "select g.group_uuid as groupUuid, " +
+    @Query(value = "select (g.group_uuid\\:\\:varchar) as groupUuid, " +
                    "(g.heading\\:\\:varchar) as heading, " +
                    "count(qg.content_uuid) as contentCount, " +
                    "count(case when qg.content_type = 'grouping' then qg.content_uuid end) as groupCount, " +

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
@@ -12,7 +12,9 @@ interface QuestionGroupRepository: JpaRepository<QuestionGroupEntity, String> {
 
     fun findByGroupGroupUuid(groupId: UUID): Collection<QuestionGroupEntity>?
 
-    @Query(value = "select (g.heading\\:\\:varchar) as heading " +
+    @Query(value = "select (g.heading\\:\\:varchar) as heading, " +
+                   "-1 as groupCount, " +
+                   "0 as questionCount " +
                    "from grouping g ",
            nativeQuery = true)
     fun listGroups(): Collection<GroupSummaryEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
@@ -12,7 +12,8 @@ interface QuestionGroupRepository: JpaRepository<QuestionGroupEntity, String> {
 
     fun findByGroupGroupUuid(groupId: UUID): Collection<QuestionGroupEntity>?
 
-    @Query(value = "select (g.heading\\:\\:varchar) as heading, " +
+    @Query(value = "select g.group_uuid as groupUuid, " +
+                   "(g.heading\\:\\:varchar) as heading, " +
                    "count(qg.content_uuid) as contentCount, " +
                    "count(case when qg.content_type = 'grouping' then qg.content_uuid end) as groupCount, " +
                    "count(case when qg.content_type = 'question' then qg.content_uuid end) as questionCount, " +

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionGroupRepository.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.assessments.jpa.repositories
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.assessments.jpa.entities.GroupSummaryEntity
 import uk.gov.justice.digital.assessments.jpa.entities.QuestionGroupEntity
 import java.util.*
 
@@ -10,4 +12,8 @@ interface QuestionGroupRepository: JpaRepository<QuestionGroupEntity, String> {
 
     fun findByGroupGroupUuid(groupId: UUID): Collection<QuestionGroupEntity>?
 
+    @Query(value = "select (g.heading\\:\\:varchar) as heading " +
+                   "from grouping g ",
+           nativeQuery = true)
+    fun listGroups(): Collection<GroupSummaryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
@@ -2,16 +2,19 @@ package uk.gov.justice.digital.assessments.services
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.assessments.api.GroupQuestionDto
+import uk.gov.justice.digital.assessments.api.GroupSummaryDto
 import uk.gov.justice.digital.assessments.api.GroupWithContentsDto
 import uk.gov.justice.digital.assessments.api.QuestionSchemaDto
 import uk.gov.justice.digital.assessments.jpa.entities.QuestionGroupEntity
 import uk.gov.justice.digital.assessments.jpa.repositories.GroupRepository
+import uk.gov.justice.digital.assessments.jpa.repositories.QuestionGroupRepository
 import uk.gov.justice.digital.assessments.jpa.repositories.QuestionSchemaRepository
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import java.util.*
 
 @Service
 class QuestionService(private val questionSchemaRepository: QuestionSchemaRepository,
+                      private val questionGroupRepository: QuestionGroupRepository,
                       private val groupRepository: GroupRepository) {
 
     fun getQuestionSchema(questionSchemaId: UUID): QuestionSchemaDto {
@@ -21,9 +24,11 @@ class QuestionService(private val questionSchemaRepository: QuestionSchemaReposi
     }
 
     fun getQuestionGroup(groupUuid:UUID): GroupWithContentsDto {
-        println(groupUuid.toString())
-
         return getQuestionGroup(groupUuid, null)
+    }
+
+    fun listGroups(): Collection<GroupSummaryDto> {
+        return questionGroupRepository.listGroups().map { GroupSummaryDto.from(it) }
     }
 
     private fun getQuestionGroup(groupUuid:UUID, parentGroup: QuestionGroupEntity?): GroupWithContentsDto {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDtoTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.assessments.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.assessments.jpa.entities.GroupSummaryEntity
+import java.util.*
+
+@DisplayName("Group Summary DTO Tests")
+class GroupSummaryDtoTest {
+    @Test
+    fun `build GroupSummary DTO`() {
+        val groupUuid = UUID.randomUUID()
+        val summary = object: GroupSummaryEntity {
+            override val groupUuid = groupUuid.toString()
+            override val heading = "Heading"
+            override val contentCount = 5L
+            override val groupCount = 2L
+            override val questionCount = 3L
+        }
+
+        val dto = GroupSummaryDto.from(summary)
+
+        /*
+        assertThat(dto.groupUuid).isEqualTo(groupUuid)
+        assertThat(dto.heading).isEqualTo(summary.heading)
+        assertThat(dto.contentCount).isEqualTo(summary.contentCount)
+        assertThat(dto.groupCount).isEqualTo(summary.groupCount)
+        assertThat(dto.questionCount).isEqualTo(summary.questionCount)
+        */
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/GroupSummaryDtoTest.kt
@@ -21,12 +21,10 @@ class GroupSummaryDtoTest {
 
         val dto = GroupSummaryDto.from(summary)
 
-        /*
-        assertThat(dto.groupUuid).isEqualTo(groupUuid)
-        assertThat(dto.heading).isEqualTo(summary.heading)
+        assertThat(dto.groupId).isEqualTo(groupUuid)
+        assertThat(dto.title).isEqualTo(summary.heading)
         assertThat(dto.contentCount).isEqualTo(summary.contentCount)
         assertThat(dto.groupCount).isEqualTo(summary.groupCount)
         assertThat(dto.questionCount).isEqualTo(summary.questionCount)
-        */
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -86,13 +86,12 @@ class QuestionControllerTest : IntegrationTest() {
 
         assertThat(groupSummaries).hasSize(1)
 
-        val groupInfo = groupSummaries.first()
+        val groupInfo = groupSummaries?.first()
 
-        assertThat(groupInfo.groupId).isEqualTo(groupUuid.toString())
-        assertThat(groupInfo.title).isEqualTo("Heading 1")
-        assertThat(groupInfo.contentCount).isEqualTo(1)
-        assertThat(groupInfo.groupCount).isEqualTo(0)
-        assertThat(groupInfo.questionCount).isEqualTo(1)
-
+        assertThat(groupInfo?.groupId).isEqualTo(UUID.fromString(groupUuid))
+        assertThat(groupInfo?.title).isEqualTo("Heading 1")
+        assertThat(groupInfo?.contentCount).isEqualTo(1)
+        assertThat(groupInfo?.groupCount).isEqualTo(0)
+        assertThat(groupInfo?.questionCount).isEqualTo(1)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -8,6 +8,7 @@ import org.springframework.test.context.jdbc.SqlConfig
 import org.springframework.test.context.jdbc.SqlGroup
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.assessments.api.GroupQuestionDto
+import uk.gov.justice.digital.assessments.api.GroupSummaryDto
 import uk.gov.justice.digital.assessments.api.GroupWithContentsDto
 import uk.gov.justice.digital.assessments.api.QuestionSchemaDto
 import java.util.*
@@ -71,5 +72,27 @@ class QuestionControllerTest : IntegrationTest() {
                 .headers(setAuthorisation())
                 .exchange()
                 .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `list groups`() {
+        val groupSummaries = webTestClient.get().uri("/questions/list")
+                .headers(setAuthorisation())
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<List<GroupSummaryDto>>()
+                .returnResult()
+                .responseBody
+
+        assertThat(groupSummaries).hasSize(1)
+
+        val groupInfo = groupSummaries.first()
+
+        assertThat(groupInfo.groupId).isEqualTo(groupUuid.toString())
+        assertThat(groupInfo.title).isEqualTo("Heading 1")
+        assertThat(groupInfo.contentCount).isEqualTo(1)
+        assertThat(groupInfo.groupCount).isEqualTo(0)
+        assertThat(groupInfo.questionCount).isEqualTo(1)
+
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
@@ -34,7 +34,7 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
 
         val groupInfo = groupSummaries.first()
 
-        assertThat(groupInfo.groupUuid).isEqualTo(groupUuid)
+        assertThat(groupInfo.groupUuid).isEqualTo(groupUuid.toString())
         assertThat(groupInfo.heading).isEqualTo("Heading 1")
         assertThat(groupInfo.contentCount).isEqualTo(1)
         assertThat(groupInfo.groupCount).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
@@ -27,4 +27,16 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
         assertThat(questionGroupEntity.contentType).isEqualTo("question")
         assertThat(questionGroupEntity.contentUuid).isEqualTo(questionSchemaUuid)
     }
+
+    @Test
+    fun `list group summaries`() {
+        val groupSummaries = questionGroupRepository.listGroups()
+
+        // assertThat(groupSummaries).hasSize(1)
+
+        val groupInfo = groupSummaries!!.first()
+        assertThat(groupInfo.heading).isEqualTo("Heading 1")
+        //assertThat(groupInfo.groupCount).isEqualTo(0)
+        //assertThat(groupInfo.questionCount).isEqualTo(1)
+    }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
@@ -31,12 +31,11 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
     @Test
     fun `list group summaries`() {
         val groupSummaries = questionGroupRepository.listGroups()
+        assertThat(groupSummaries).hasSize(1)
 
-        // assertThat(groupSummaries).hasSize(1)
-
-        val groupInfo = groupSummaries!!.first()
+        val groupInfo = groupSummaries.first()
         assertThat(groupInfo.heading).isEqualTo("Heading 1")
-        //assertThat(groupInfo.groupCount).isEqualTo(0)
-        //assertThat(groupInfo.questionCount).isEqualTo(1)
+        assertThat(groupInfo.groupCount).isEqualTo(0)
+        assertThat(groupInfo.questionCount).isEqualTo(1)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
@@ -34,7 +34,7 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
 
         val groupInfo = groupSummaries.first()
 
-        //assertThat(groupInfo.groupUuid).isEqualTo(groupUuid)
+        assertThat(groupInfo.groupUuid).isEqualTo(groupUuid)
         assertThat(groupInfo.heading).isEqualTo("Heading 1")
         assertThat(groupInfo.contentCount).isEqualTo(1)
         assertThat(groupInfo.groupCount).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
@@ -14,12 +14,11 @@ import java.util.*
         Sql(scripts = ["classpath:referenceData/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
         Sql(scripts = ["classpath:referenceData/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
 class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: QuestionGroupRepository) : IntegrationTest() {
+    val groupUuid = UUID.fromString("e353f3df-113d-401c-a3c0-14239fc17cf9")
+    val questionSchemaUuid = UUID.fromString("fd412ca8-d361-47ab-a189-7acb8ae0675b")
 
     @Test
     fun `fetch group contents`() {
-        val groupUuid = UUID.fromString("e353f3df-113d-401c-a3c0-14239fc17cf9")
-        val questionSchemaUuid = UUID.fromString("fd412ca8-d361-47ab-a189-7acb8ae0675b")
-
         val questionGroupEntities = questionGroupRepository.findByGroupGroupUuid(groupUuid)
         assertThat(questionGroupEntities).hasSize(1)
 
@@ -34,7 +33,10 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
         assertThat(groupSummaries).hasSize(1)
 
         val groupInfo = groupSummaries.first()
+
+        //assertThat(groupInfo.groupUuid).isEqualTo(groupUuid)
         assertThat(groupInfo.heading).isEqualTo("Heading 1")
+        assertThat(groupInfo.contentCount).isEqualTo(1)
         assertThat(groupInfo.groupCount).isEqualTo(0)
         assertThat(groupInfo.questionCount).isEqualTo(1)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
@@ -47,7 +47,6 @@ class QuestionServiceTest {
         verify(exactly = 1) { questionSchemaRepository.findByQuestionSchemaUuid(uuid) }
     }
 
-
 //    @Test
 //    fun `should return Questions for group`() {
 //        val groupId = UUID.randomUUID()
@@ -58,13 +57,5 @@ class QuestionServiceTest {
 //
 //        verify(exactly = 1) { questionSchemaRepository.findByQuestionSchemaId(questionSchemaId) }
 //        assertThat(questionSchemaDto).isEqualTo(QuestionSchemaDto(questionSchemaId))
-//    }
-
-//    @Test
-//    fun `should throw exception when Question Schema does not exist with ID`() {
-//        every { questionSchemaRepository.findByQuestionSchemaId(questionSchemaId) } returns null
-//
-//        assertThrows<EntityNotFoundException> { questionService.getQuestionSchema(questionSchemaId) }
-//        verify(exactly = 1) { questionSchemaRepository.findByQuestionSchemaId(questionSchemaId) }
 //    }
 }

--- a/src/test/resources/referenceData/before-test.sql
+++ b/src/test/resources/referenceData/before-test.sql
@@ -1,4 +1,11 @@
 -- noinspection SqlResolveForFile
+DELETE FROM answer_schema WHERE true;
+
+DELETE FROM question_group WHERE true;
+
+DELETE FROM QUESTION_SCHEMA WHERE true;
+DELETE FROM grouping WHERE true;
+
 
 INSERT INTO question_schema (question_schema_id, question_schema_uuid, question_code, oasys_question_code, question_start, question_end, answer_type, question_text, question_help_text)
 VALUES (0, 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'RSR_01', 'RSR_01', '2019-11-14 08:11:53.177108', null, 'radio', 'Question text', 'Help text');


### PR DESCRIPTION
Adds /questions/list endpoint

Lists the available question groups - their id, title, and summary information about their contents.

At the moment, this is primarily intend for so we can list them out in the front end and jump around between them.