### PR TITLE
Arn 151 parent child questions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AnswerSchemaDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AnswerSchemaDto.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.assessments.api
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaEntity
+import uk.gov.justice.digital.assessments.services.AnswerDependencies
+import uk.gov.justice.digital.assessments.services.QuestionDependencies
 import java.util.*
 
 data class AnswerSchemaDto (
@@ -15,22 +17,32 @@ data class AnswerSchemaDto (
         val value: String? = null,
 
         @Schema(description = "Answer Text", example = "Some answer text")
-        val text: String? = null
+        val text: String? = null,
+
+        @Schema(description = "Does setting the question to this value trigger the display of another question?", example = "<UUID>")
+        val conditional: UUID? = null
 
 ) {
     companion object{
 
-        fun from(answerSchemaEntities: Collection<AnswerSchemaEntity>?): Set<AnswerSchemaDto>{
+        fun from(
+                answerSchemaEntities: Collection<AnswerSchemaEntity>?,
+                answerDependencies: AnswerDependencies = { null }
+        ): Set<AnswerSchemaDto>{
             if (answerSchemaEntities.isNullOrEmpty()) return emptySet()
-            return answerSchemaEntities.map { from(it) }.toSet()
+            return answerSchemaEntities.map { from(it, answerDependencies) }.toSet()
         }
 
-        fun from(answerSchemaEntity: AnswerSchemaEntity): AnswerSchemaDto{
+        fun from(
+                answerSchemaEntity: AnswerSchemaEntity,
+                answerDependencies: AnswerDependencies
+        ): AnswerSchemaDto{
             return AnswerSchemaDto(
                     answerSchemaEntity.answerSchemaUuid,
                     answerSchemaEntity.answerSchemaCode,
                     answerSchemaEntity.value,
-                    answerSchemaEntity.text
+                    answerSchemaEntity.text,
+                    answerDependencies(answerSchemaEntity.value)
             )
         }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/QuestionDependencyEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/QuestionDependencyEntity.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.assessments.jpa.entities
+
+import java.time.LocalDateTime
+import java.util.*
+import javax.persistence.*
+
+@Entity
+@Table(name = "question_dependency")
+class QuestionDependencyEntity (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dependency_id")
+    val dependencyId: Long,
+
+    @Column(name = "subject_question_uuid")
+    val subjectQuestionUuid: UUID,
+
+    @Column(name = "trigger_question_uuid")
+    val triggerQuestionUuid: UUID,
+
+    @Column(name = "trigger_answer_value")
+    val triggerAnswerValue: String,
+
+    @Column(name = "dependency_start")
+    val startDate: LocalDateTime? = null,
+
+    @Column(name = "dependency_end")
+    val endDate: LocalDateTime? = null
+)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionDependencyRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionDependencyRepository.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.assessments.jpa.repositories
 
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.assessments.jpa.entities.QuestionDependencyEntity
 
-class QuestionDependencyRepository {
-    fun findDependencies(): Collection<String> = emptyList()
+@Repository
+interface QuestionDependencyRepository: JpaRepository<QuestionDependencyEntity, String> {
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionDependencyRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/repositories/QuestionDependencyRepository.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.assessments.jpa.repositories
+
+
+class QuestionDependencyRepository {
+    fun findDependencies(): Collection<String> = emptyList()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependencyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependencyService.kt
@@ -16,6 +16,8 @@ class QuestionDependencyService(
     }
 }
 
+typealias AnswerDependencies = (String?) -> UUID?
+
 class QuestionDependencies(questionDeps: Collection<QuestionDependencyEntity>) {
     private val subjects = questionDeps.map { it.subjectQuestionUuid }
     private val triggers = questionDeps.associateBy(
@@ -24,6 +26,9 @@ class QuestionDependencies(questionDeps: Collection<QuestionDependencyEntity>) {
     )
 
     fun hasDependency(subjectUuid: UUID): Boolean = subjects.contains(subjectUuid)
-    fun triggersDependency(triggerUuid: UUID, answerValue: String): UUID? =
+    fun triggersDependency(triggerUuid: UUID, answerValue: String?): UUID? =
             triggers.get(Pair(triggerUuid, answerValue))
+    fun answerTriggers(triggerUuid: UUID): AnswerDependencies {
+        return {  answerValue: String? -> triggersDependency(triggerUuid, answerValue) }
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependencyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependencyService.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.assessments.services
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.assessments.jpa.entities.QuestionDependencyEntity
+import uk.gov.justice.digital.assessments.jpa.repositories.QuestionDependencyRepository
+import java.util.*
+
+@Service
+class QuestionDependencyService(
+        private val questionDependencyRepository: QuestionDependencyRepository
+) {
+    fun dependencies(): QuestionDependencies {
+        val qd = questionDependencyRepository.findAll()
+
+        return QuestionDependencies(qd)
+    }
+}
+
+class QuestionDependencies(questionDeps: Collection<QuestionDependencyEntity>) {
+    private val subjects = questionDeps.map { it.subjectQuestionUuid }
+    private val triggers = questionDeps.associateBy(
+            { Pair(it.triggerQuestionUuid, it.triggerAnswerValue) },
+            { it.subjectQuestionUuid }
+    )
+
+    fun hasDependency(subjectUuid: UUID): Boolean = subjects.contains(subjectUuid)
+    fun triggersDependency(triggerUuid: UUID, answerValue: String): UUID? =
+            triggers.get(Pair(triggerUuid, answerValue))
+}

--- a/src/main/resources/db/migration/V1_7__question_dependency.sql
+++ b/src/main/resources/db/migration/V1_7__question_dependency.sql
@@ -1,0 +1,11 @@
+-- noinspection SqlResolveForFile
+
+CREATE TABLE IF NOT EXISTS question_dependency
+(
+    dependency_id           SERIAL      PRIMARY KEY,
+    subject_question_uuid   UUID        NOT NULL,
+    trigger_question_uuid   UUID        NOT NULL,
+    trigger_answer_value    TEXT        NOT NULL,
+    dependency_start        TIMESTAMP   NOT NULL,
+    dependency_end          TIMESTAMP
+);

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/GroupWithContentsDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/GroupWithContentsDtoTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import uk.gov.justice.digital.assessments.jpa.entities.QuestionGroupEntity
 import uk.gov.justice.digital.assessments.jpa.entities.QuestionSchemaEntity
 import uk.gov.justice.digital.assessments.jpa.entities.GroupEntity
+import uk.gov.justice.digital.assessments.services.QuestionDependencies
 import java.time.LocalDateTime
 import java.util.*
 
@@ -145,12 +146,11 @@ class GroupWithContentsDtoTest {
     private fun makeQuestionGroupDto(group: GroupEntity, vararg contents: QuestionGroupEntity): GroupWithContentsDto {
         val contentsDto: List<GroupContentDto> = contents.map {
             when(it.contentType) {
-                "question" -> GroupQuestionDto.from(it.question!!, it)
+                "question" -> GroupQuestionDto.from(it.question!!, it, QuestionDependencies(emptyList()))
                 "group" -> GroupWithContentsDto.from(it.nestedGroup!!, emptyList(), it)
                 else -> throw Exception("oh no")
             }
         }
-
 
         return GroupWithContentsDto.from(group, contentsDto)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -22,6 +22,7 @@ class QuestionControllerTest : IntegrationTest() {
 
     private val groupUuid = "e353f3df-113d-401c-a3c0-14239fc17cf9"
     private val questionSchemaUuid = "fd412ca8-d361-47ab-a189-7acb8ae0675b"
+    private val subjectQuestionUuid = "1948af63-07f2-4a8c-9e4c-0ec347bd6ba8"
     private val answerSchemaUuid = "464e25da-f843-43b6-8223-4af415abda0c"
 
     @Test
@@ -87,6 +88,28 @@ class QuestionControllerTest : IntegrationTest() {
     }
 
     @Test
+    fun `verify dependency conditionals`() {
+        val questions = webTestClient.get().uri("/questions/Group code")
+                .headers(setAuthorisation())
+                .exchange()
+                .expectStatus().isOk
+                .expectBody<GroupWithContentsDto>()
+                .returnResult()
+                .responseBody
+                ?.contents
+
+        val subjectQuestion = questions?.find { (it as GroupQuestionDto).questionId.toString() == subjectQuestionUuid } as GroupQuestionDto
+        assertThat(subjectQuestion.conditional).isTrue()
+
+        val triggerQuestion = questions?.find { (it as GroupQuestionDto).questionId.toString() == questionSchemaUuid } as GroupQuestionDto
+        assertThat(triggerQuestion.conditional).isFalse()
+        val yesAnswer = triggerQuestion.answerSchemas?.find { it.value == "true"}
+        assertThat(yesAnswer?.conditional.toString()).isEqualTo(subjectQuestionUuid)
+        val noAnswer = triggerQuestion.answerSchemas?.find { it.value == "false"}
+        assertThat(noAnswer?.conditional).isNull()
+    }
+
+    @Test
     fun `get questions returns not found when group does not exist`() {
         val invalidGroupUuid = UUID.randomUUID()
         webTestClient.get().uri("/questions/$invalidGroupUuid")
@@ -111,8 +134,8 @@ class QuestionControllerTest : IntegrationTest() {
 
         assertThat(groupInfo?.groupId).isEqualTo(UUID.fromString(groupUuid))
         assertThat(groupInfo?.title).isEqualTo("Heading 1")
-        assertThat(groupInfo?.contentCount).isEqualTo(1)
+        assertThat(groupInfo?.contentCount).isEqualTo(2)
         assertThat(groupInfo?.groupCount).isEqualTo(0)
-        assertThat(groupInfo?.questionCount).isEqualTo(1)
+        assertThat(groupInfo?.questionCount).isEqualTo(2)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -62,8 +62,8 @@ class QuestionControllerTest : IntegrationTest() {
         val questionRef = questionRefs?.get(0) as GroupQuestionDto
         assertThat(questionRef.questionId).isEqualTo(UUID.fromString(questionSchemaUuid))
 
-        val answerRefs = questionRef.answerSchemas
-        assertThat(answerRefs?.first()?.answerSchemaUuid).isEqualTo(UUID.fromString(answerSchemaUuid))
+        val answerSchemaUuids = questionRef.answerSchemas?.map { it.answerSchemaUuid }
+        assertThat(answerSchemaUuids).contains(UUID.fromString(answerSchemaUuid))
     }
 
     @Test
@@ -82,8 +82,8 @@ class QuestionControllerTest : IntegrationTest() {
         val questionRef = questionRefs?.get(0) as GroupQuestionDto
         assertThat(questionRef.questionId).isEqualTo(UUID.fromString(questionSchemaUuid))
 
-        val answerRefs = questionRef.answerSchemas
-        assertThat(answerRefs?.first()?.answerSchemaUuid).isEqualTo(UUID.fromString(answerSchemaUuid))
+        val answerSchemaUuids = questionRef.answerSchemas?.map { it.answerSchemaUuid }
+        assertThat(answerSchemaUuids).contains(UUID.fromString(answerSchemaUuid))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionDependencyRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionDependencyRepositoryTest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.assessments.repositories
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import org.springframework.test.context.jdbc.SqlGroup
+import uk.gov.justice.digital.assessments.jpa.repositories.QuestionDependencyRepository
+import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+
+@SqlGroup(
+        Sql(scripts = ["classpath:referenceData/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
+        Sql(scripts = ["classpath:referenceData/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
+class QuestionDependencyRepositoryTest(
+        @Autowired
+        val questionDependencyRepository: QuestionDependencyRepository
+) : IntegrationTest() {
+    @Test
+    fun `fetch all dependencies`() {
+        val dependencies = questionDependencyRepository.findDependencies()
+
+        assertThat(dependencies.size).isEqualTo(2)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionDependencyRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionDependencyRepositoryTest.kt
@@ -10,15 +10,15 @@ import uk.gov.justice.digital.assessments.jpa.repositories.QuestionDependencyRep
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
 @SqlGroup(
-        Sql(scripts = ["classpath:referenceData/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
-        Sql(scripts = ["classpath:referenceData/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
+        Sql(scripts = ["classpath:assessments/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
+        Sql(scripts = ["classpath:assessments/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
 class QuestionDependencyRepositoryTest(
         @Autowired
         val questionDependencyRepository: QuestionDependencyRepository
 ) : IntegrationTest() {
     @Test
     fun `fetch all dependencies`() {
-        val dependencies = questionDependencyRepository.findDependencies()
+        val dependencies = questionDependencyRepository.findAll()
 
         assertThat(dependencies.size).isEqualTo(2)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionDependencyRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionDependencyRepositoryTest.kt
@@ -10,8 +10,8 @@ import uk.gov.justice.digital.assessments.jpa.repositories.QuestionDependencyRep
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
 @SqlGroup(
-        Sql(scripts = ["classpath:assessments/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
-        Sql(scripts = ["classpath:assessments/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
+        Sql(scripts = ["classpath:referenceData/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
+        Sql(scripts = ["classpath:referenceData/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
 class QuestionDependencyRepositoryTest(
         @Autowired
         val questionDependencyRepository: QuestionDependencyRepository
@@ -20,6 +20,6 @@ class QuestionDependencyRepositoryTest(
     fun `fetch all dependencies`() {
         val dependencies = questionDependencyRepository.findAll()
 
-        assertThat(dependencies.size).isEqualTo(2)
+        assertThat(dependencies.size).isEqualTo(3)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
@@ -20,7 +20,7 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
     @Test
     fun `fetch group contents`() {
         val questionGroupEntities = questionGroupRepository.findByGroupGroupUuid(groupUuid)
-        assertThat(questionGroupEntities).hasSize(1)
+        assertThat(questionGroupEntities).hasSize(2)
 
         val questionGroupEntity = questionGroupEntities!!.first()
         assertThat(questionGroupEntity.contentType).isEqualTo("question")
@@ -36,8 +36,8 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
 
         assertThat(groupInfo.groupUuid).isEqualTo(groupUuid.toString())
         assertThat(groupInfo.heading).isEqualTo("Heading 1")
-        assertThat(groupInfo.contentCount).isEqualTo(1)
+        assertThat(groupInfo.contentCount).isEqualTo(2)
         assertThat(groupInfo.groupCount).isEqualTo(0)
-        assertThat(groupInfo.questionCount).isEqualTo(1)
+        assertThat(groupInfo.questionCount).isEqualTo(2)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependenciesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependenciesTest.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 import java.util.*
 
 @SqlGroup(
-        Sql(scripts = ["classpath:assessments/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
-        Sql(scripts = ["classpath:assessments/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
+        Sql(scripts = ["classpath:referenceData/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
+        Sql(scripts = ["classpath:referenceData/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
 class QuestionDependenciesTest (
         @Autowired
         private val questionDependencyService: QuestionDependencyService

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependenciesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionDependenciesTest.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.assessments.services
+
+import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import org.springframework.test.context.jdbc.SqlGroup
+import uk.gov.justice.digital.assessments.jpa.repositories.QuestionDependencyRepository
+import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import java.util.*
+
+@SqlGroup(
+        Sql(scripts = ["classpath:assessments/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
+        Sql(scripts = ["classpath:assessments/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD))
+class QuestionDependenciesTest (
+        @Autowired
+        private val questionDependencyService: QuestionDependencyService
+) : IntegrationTest() {
+    val subjectUuid = UUID.fromString("11111111-1111-1111-1111-111111111113")
+    val triggerUuid = UUID.fromString("11111111-1111-1111-1111-111111111112")
+    lateinit var dependencies: QuestionDependencies
+
+    @BeforeEach
+    fun setup() {
+        dependencies = questionDependencyService.dependencies()
+    }
+
+    @Test
+    fun `question has a dependency`() {
+        assertThat(dependencies.hasDependency(subjectUuid)).isTrue()
+    }
+
+    @Test
+    fun `question has no dependency`() {
+        assertThat(dependencies.hasDependency(triggerUuid)).isFalse()
+    }
+
+    @Test
+    fun `question triggers a dependency`() {
+        assertThat(dependencies.triggersDependency(triggerUuid, "Y")).isEqualTo(subjectUuid)
+    }
+
+    @Test
+    fun `question triggers that has no trigger`() {
+        assertThat(dependencies.triggersDependency(triggerUuid, "N")).isEqualTo(null)
+        assertThat(dependencies.triggersDependency(subjectUuid, "Y")).isEqualTo(null)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
@@ -31,11 +31,13 @@ class QuestionServiceTest {
     private val answerSchemaRepository: AnswerSchemaRepository = mockk()
     private val questionGroupRepository: QuestionGroupRepository = mockk()
     private val groupRepository: GroupRepository = mockk()
+    private val dependencyService: QuestionDependencyService = mockk()
     private val questionService = QuestionService(
             questionSchemaRepository,
             questionGroupRepository,
             groupRepository,
-            answerSchemaRepository
+            answerSchemaRepository,
+            dependencyService
     )
 
     private val questionId = 1L
@@ -91,6 +93,7 @@ class QuestionServiceTest {
     fun `get group contents`() {
         every { questionSchemaRepository.findByQuestionSchemaUuid(questionUuid) } returns question
         every { groupRepository.findByGroupUuid(groupUuid) } returns group
+        every { dependencyService.dependencies() } returns QuestionDependencies(emptyList())
 
         val groupQuestions = questionService.getQuestionGroup(groupUuid)
 

--- a/src/test/resources/assessments/after-test.sql
+++ b/src/test/resources/assessments/after-test.sql
@@ -3,5 +3,4 @@
 delete from assessed_episode where true;
 delete from subject where true;
 delete from assessment where true;
-delete from question_dependency where true;
 

--- a/src/test/resources/assessments/after-test.sql
+++ b/src/test/resources/assessments/after-test.sql
@@ -3,4 +3,5 @@
 delete from assessed_episode where true;
 delete from subject where true;
 delete from assessment where true;
+delete from question_dependency where true;
 

--- a/src/test/resources/assessments/before-test.sql
+++ b/src/test/resources/assessments/before-test.sql
@@ -18,8 +18,3 @@ insert into assessed_episode  (episode_id, episode_uuid, user_id, created_date, 
 /* Empty assessment */
 insert into assessment  (assessment_id, assessment_uuid, supervision_id, created_date) values
 (3, 'f9a07b3f-91b7-45a7-a5ca-2d98cf1147d8', 'CRN2', '2020-1-14 09:00');
-
-/* Question Dependency */
-insert into question_dependency (subject_question_uuid, trigger_question_uuid, trigger_answer_value, dependency_start) values
-('11111111-1111-1111-1111-111111111113', '11111111-1111-1111-1111-111111111112', 'Y', '2020-1-14 09:00'),
-('11111111-1111-1111-1111-111111111116', '11111111-1111-1111-1111-111111111115', 'Y', '2020-1-14 09:00');

--- a/src/test/resources/assessments/before-test.sql
+++ b/src/test/resources/assessments/before-test.sql
@@ -15,8 +15,11 @@ insert into assessed_episode  (episode_id, episode_uuid, user_id, created_date, 
 (1, 'd7aafe55-0cff-4f20-a57a-b66d79eb9c91', 'USER1', '2019-11-14 09:00', '2019-11-14 12:00','Change of Circs', '2e020e78-a81c-407f-bc78-e5f284e237e5', '{}'),
 (2, 'f3569440-efd5-4289-8fdd-4560360e5259', 'USER1', '2019-11-14 09:00', null,'More Change of Circs', '2e020e78-a81c-407f-bc78-e5f284e237e5', '{}');
 
-
 /* Empty assessment */
 insert into assessment  (assessment_id, assessment_uuid, supervision_id, created_date) values
 (3, 'f9a07b3f-91b7-45a7-a5ca-2d98cf1147d8', 'CRN2', '2020-1-14 09:00');
 
+/* Question Dependency */
+insert into question_dependency (subject_question_uuid, trigger_question_uuid, trigger_answer_value, dependency_start) values
+('11111111-1111-1111-1111-111111111113', '11111111-1111-1111-1111-111111111112', 'Y', '2020-1-14 09:00'),
+('11111111-1111-1111-1111-111111111116', '11111111-1111-1111-1111-111111111115', 'Y', '2020-1-14 09:00');

--- a/src/test/resources/referenceData/after-test.sql
+++ b/src/test/resources/referenceData/after-test.sql
@@ -7,3 +7,4 @@ DELETE FROM question_group WHERE true;
 DELETE FROM QUESTION_SCHEMA WHERE true;
 DELETE FROM grouping WHERE true;
 
+delete from question_dependency where true;

--- a/src/test/resources/referenceData/before-test.sql
+++ b/src/test/resources/referenceData/before-test.sql
@@ -14,10 +14,17 @@ VALUES (0, '464e25da-f843-43b6-8223-4af415abda0c', 'RSR_01a','f756f79d-dfad-49f9
        (1, '0a428566-6393-462f-addb-50feaaf75d57', 'RSR_01b','f756f79d-dfad-49f9-a1b9-964a41cf660d', '2019-11-14 08:11:53.177108', null, 'false', 'No');
 
 INSERT INTO question_schema (question_schema_id, question_schema_uuid, question_code, oasys_question_code, question_start, question_end, answer_type, answer_schema_group_uuid, question_text, question_help_text)
-VALUES (0, 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'RSR_01', 'RSR_01', '2019-11-14 08:11:53.177108', null, 'radio', 'f756f79d-dfad-49f9-a1b9-964a41cf660d', 'Question text', 'Help text');
+VALUES (0, 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'RSR_01', 'RSR_01', '2019-11-14 08:11:53.177108', null, 'radio', 'f756f79d-dfad-49f9-a1b9-964a41cf660d', 'Question text', 'Help text'),
+       (1, '1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'RSR_01_conditional', 'RSR_01_conditional', '2019-11-14 08:11:53.177108', null, 'freetext', null, 'Question text', 'Help text');
 
 INSERT INTO grouping (group_id, group_uuid, group_code, heading, subheading, help_text, group_start, group_end)
 VALUES (0, 'e353f3df-113d-401c-a3c0-14239fc17cf9', 'Group code', 'Heading 1', 'Subheading 1', 'Help text', '2019-11-14 08:11:53.177108', null);
 
 INSERT INTO question_group (question_group_id, question_group_uuid, content_uuid, content_type, group_uuid, display_order, mandatory, validation)
 VALUES (0, '334f3e21-b249-4c7f-848e-05c0d2aad8f4', 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'question', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '1', true, null );
+
+/* Question Dependency */
+insert into question_dependency (subject_question_uuid, trigger_question_uuid, trigger_answer_value, dependency_start) values
+('11111111-1111-1111-1111-111111111113', '11111111-1111-1111-1111-111111111112', 'Y', '2020-1-14 09:00'),
+('11111111-1111-1111-1111-111111111116', '11111111-1111-1111-1111-111111111115', 'Y', '2020-1-14 09:00'),
+('1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'Yes', '2020-1-14 09:00');

--- a/src/test/resources/referenceData/before-test.sql
+++ b/src/test/resources/referenceData/before-test.sql
@@ -21,10 +21,11 @@ INSERT INTO grouping (group_id, group_uuid, group_code, heading, subheading, hel
 VALUES (0, 'e353f3df-113d-401c-a3c0-14239fc17cf9', 'Group code', 'Heading 1', 'Subheading 1', 'Help text', '2019-11-14 08:11:53.177108', null);
 
 INSERT INTO question_group (question_group_id, question_group_uuid, content_uuid, content_type, group_uuid, display_order, mandatory, validation)
-VALUES (0, '334f3e21-b249-4c7f-848e-05c0d2aad8f4', 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'question', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '1', true, null );
+VALUES (0, '334f3e21-b249-4c7f-848e-05c0d2aad8f4', 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'question', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '1', true, null ),
+       (1, 'fcec5c32-ea96-424c-80a5-8186dc414619', '1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'question', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '2', false, null );
 
 /* Question Dependency */
 insert into question_dependency (subject_question_uuid, trigger_question_uuid, trigger_answer_value, dependency_start) values
 ('11111111-1111-1111-1111-111111111113', '11111111-1111-1111-1111-111111111112', 'Y', '2020-1-14 09:00'),
 ('11111111-1111-1111-1111-111111111116', '11111111-1111-1111-1111-111111111115', 'Y', '2020-1-14 09:00'),
-('1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'Yes', '2020-1-14 09:00');
+('1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'true', '2020-1-14 09:00');


### PR DESCRIPTION
Back-end to support condition question display in the UI.

I've modelled this with a new table, question_dependency, which maps a _subject question_ to a _trigger question and value_. In the UI, then the trigger question has that value, the subject question is visible otherwise it is hidden. 

There's the usual repository boilerplate over the top of it, with a simple service to make querying the dependencies easier. When I say simple, at the moment, it really is dead simple, but we should be able to expand it out for date ranges and so on when we come to do elsewhere. 

The dependency information is injected into the GroupQuestionDto to be splatted out as JSON to the UI.