### PR TITLE
Arn 297 assessment sections

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupSectionsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupSectionsDto.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.assessments.api
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.assessments.jpa.entities.GroupEntity
+import uk.gov.justice.digital.assessments.jpa.entities.QuestionGroupEntity
+import java.util.UUID
+
+data class GroupSectionsDto(
+  @Schema(description = "Group Identifier", example = "<uuid>")
+  val groupId: UUID,
+
+  @Schema(description = "Group Code", example = "group-code-name")
+  val groupCode: String,
+
+  @Schema(description = "Group Title", example = "Some group!")
+  val title: String? = null,
+
+  @Schema(description = "Group Subheading", example = "Some group subheading")
+  val subheading: String? = null,
+
+  @Schema(description = "Group Help-text", example = "Some group help text")
+  val helpText: String? = null,
+
+  @Schema(description = "Questions and Groups")
+  val contents: List<GroupSectionsDto>?
+) {
+  companion object {
+    fun from(group: GroupEntity, contents: List<GroupSectionsDto>?): GroupSectionsDto {
+      return GroupSectionsDto(
+        groupId = group.groupUuid,
+        groupCode = group.groupCode,
+        title = group.heading,
+        subheading = group.subheading,
+        helpText = group.helpText,
+        contents = contents
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
@@ -50,4 +50,16 @@ class QuestionController(val questionService: QuestionService) {
   fun getQuestionsForGroup(@PathVariable("groupCode") groupCode: String): GroupWithContentsDto {
     return questionService.getQuestionGroup(groupCode)
   }
+
+  @RequestMapping(path = ["/sections/{groupCode}"], method = [RequestMethod.GET])
+  @Operation(description = "Gets Questions for a Group")
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "404", description = "Questions not found for Group"),
+      ApiResponse(responseCode = "200", description = "OK")
+    ]
+  )
+  fun getSectionsForGroup(@PathVariable("groupCode") groupCode: String): GroupWithContentsDto {
+    return questionService.getQuestionGroup(groupCode)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.assessments.api.GroupSectionsDto
 import uk.gov.justice.digital.assessments.api.GroupSummaryDto
 import uk.gov.justice.digital.assessments.api.GroupWithContentsDto
 import uk.gov.justice.digital.assessments.api.QuestionSchemaDto
@@ -59,7 +60,7 @@ class QuestionController(val questionService: QuestionService) {
       ApiResponse(responseCode = "200", description = "OK")
     ]
   )
-  fun getSectionsForGroup(@PathVariable("groupCode") groupCode: String): GroupWithContentsDto {
+  fun getSectionsForGroup(@PathVariable("groupCode") groupCode: String): GroupSectionsDto {
     return questionService.getGroupSections(groupCode)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
@@ -60,6 +60,6 @@ class QuestionController(val questionService: QuestionService) {
     ]
   )
   fun getSectionsForGroup(@PathVariable("groupCode") groupCode: String): GroupWithContentsDto {
-    return questionService.getGroupContents(groupCode)
+    return questionService.getGroupSections(groupCode)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
@@ -48,7 +48,7 @@ class QuestionController(val questionService: QuestionService) {
     ]
   )
   fun getQuestionsForGroup(@PathVariable("groupCode") groupCode: String): GroupWithContentsDto {
-    return questionService.getQuestionGroup(groupCode)
+    return questionService.getGroupContents(groupCode)
   }
 
   @RequestMapping(path = ["/sections/{groupCode}"], method = [RequestMethod.GET])
@@ -60,6 +60,6 @@ class QuestionController(val questionService: QuestionService) {
     ]
   )
   fun getSectionsForGroup(@PathVariable("groupCode") groupCode: String): GroupWithContentsDto {
-    return questionService.getQuestionGroup(groupCode)
+    return questionService.getGroupContents(groupCode)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/QuestionController.kt
@@ -52,8 +52,8 @@ class QuestionController(val questionService: QuestionService) {
     return questionService.getGroupContents(groupCode)
   }
 
-  @RequestMapping(path = ["/sections/{groupCode}"], method = [RequestMethod.GET])
-  @Operation(description = "Gets Questions for a Group")
+  @RequestMapping(path = ["/questions/{groupCode}/summary"], method = [RequestMethod.GET])
+  @Operation(description = "Gets Summary information for a group")
   @ApiResponses(
     value = [
       ApiResponse(responseCode = "404", description = "Questions not found for Group"),

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
@@ -34,11 +34,11 @@ class QuestionService(
     return questionGroupRepository.listGroups().map { GroupSummaryDto.from(it) }
   }
 
-  fun getQuestionGroup(groupCode: String): GroupWithContentsDto {
+  fun getGroupContents(groupCode: String): GroupWithContentsDto {
     return getQuestionGroupContents(findByGroupCode(groupCode))
   }
 
-  fun getQuestionGroup(groupUuid: UUID): GroupWithContentsDto {
+  fun getGroupContents(groupUuid: UUID): GroupWithContentsDto {
     return getQuestionGroupContents(findByGroupUuid(groupUuid))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
@@ -42,6 +42,10 @@ class QuestionService(
     return getQuestionGroupContents(findByGroupUuid(groupUuid))
   }
 
+  fun getGroupSections(groupCode: String): GroupWithContentsDto {
+    return fetchGroupSections(findByGroupCode(groupCode))
+  }
+
   private fun getQuestionGroupContents(group: GroupEntity) =
     getQuestionGroupContents(
       group,
@@ -69,6 +73,21 @@ class QuestionService(
           else -> throw EntityNotFoundException("Bad group content type")
         }
       }
+
+    return GroupWithContentsDto.from(group, contents, parentGroup)
+  }
+
+  private fun fetchGroupSections(
+    group: GroupEntity,
+    parentGroup: QuestionGroupEntity? = null,
+    depth: Int = 0
+  ): GroupWithContentsDto {
+    val groupContents = group.contents.sortedBy { it.displayOrder }
+    if (groupContents.isEmpty()) throw EntityNotFoundException("Questions not found for Group: ${group.groupUuid}")
+
+    val contents = groupContents
+      .filter { it.contentType == "group" }
+      .map { fetchGroupSections(findByGroupUuid(it.contentUuid), it, depth + 1) }
 
     return GroupWithContentsDto.from(group, contents, parentGroup)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -7,10 +7,7 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import org.springframework.test.context.jdbc.SqlGroup
 import org.springframework.test.web.reactive.server.expectBody
-import uk.gov.justice.digital.assessments.api.GroupQuestionDto
-import uk.gov.justice.digital.assessments.api.GroupSummaryDto
-import uk.gov.justice.digital.assessments.api.GroupWithContentsDto
-import uk.gov.justice.digital.assessments.api.QuestionSchemaDto
+import uk.gov.justice.digital.assessments.api.*
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 import java.util.UUID
 
@@ -134,24 +131,23 @@ class QuestionControllerTest : IntegrationTest() {
       .headers(setAuthorisation())
       .exchange()
       .expectStatus().isOk
-      .expectBody<GroupWithContentsDto>()
+      .expectBody<GroupSectionsDto>()
       .returnResult()
       .responseBody
 
     assertThat(assessmentGroup.groupId).isEqualTo(UUID.fromString(assessmentGroupUuid))
 
-    val sections = assessmentGroup.contents
+    val sections = assessmentGroup.contents!!
     assertThat(sections.size).isEqualTo(1)
 
-    val section = sections.first() as GroupWithContentsDto
+    val section = sections.first()
     assertThat(section.groupId).isEqualTo(UUID.fromString(groupUuid))
 
-    val subsections = section.contents
+    val subsections = section.contents!!
     assertThat(subsections.size).isEqualTo(1)
 
-    val subsection = subsections.first() as GroupWithContentsDto
+    val subsection = subsections.first()
     assertThat(subsection.groupId).isEqualTo(UUID.fromString(subgroupUuid))
-    assertThat(subsection.contents.size).isEqualTo(0)
+    assertThat(subsection.contents).isNull()
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -21,10 +21,13 @@ import java.util.UUID
 @AutoConfigureWebTestClient
 class QuestionControllerTest : IntegrationTest() {
 
+  private val assessmentUuid = "e964d699-cf96-4abd-af0e-ddf1f6687a46"
   private val groupUuid = "e353f3df-113d-401c-a3c0-14239fc17cf9"
+  private val subgroupUuid = "6afbe596-9956-4620-824b-c6c9000ace7c"
   private val questionSchemaUuid = "fd412ca8-d361-47ab-a189-7acb8ae0675b"
   private val subjectQuestionUuid = "1948af63-07f2-4a8c-9e4c-0ec347bd6ba8"
   private val answerSchemaUuid = "464e25da-f843-43b6-8223-4af415abda0c"
+  private val subquestionUuid = "b9dd3680-c4d6-403e-8f27-8d65481cbf44"
 
   @Test
   fun `access forbidden when no authority`() {
@@ -60,31 +63,17 @@ class QuestionControllerTest : IntegrationTest() {
     assertThat(questionsGroup?.groupId).isEqualTo(UUID.fromString(groupUuid))
 
     val questionRefs = questionsGroup?.contents
-    val questionRef = questionRefs?.get(0) as GroupQuestionDto
+    val questionRef = questionRefs?.first() as GroupQuestionDto
     assertThat(questionRef.questionId).isEqualTo(UUID.fromString(questionSchemaUuid))
 
     val answerSchemaUuids = questionRef.answerSchemas?.map { it.answerSchemaUuid }
     assertThat(answerSchemaUuids).contains(UUID.fromString(answerSchemaUuid))
-  }
 
-  @Test
-  fun `get all reference questions and answers for group by code`() {
-    val questionsGroup = webTestClient.get().uri("/questions/Group code")
-      .headers(setAuthorisation())
-      .exchange()
-      .expectStatus().isOk
-      .expectBody<GroupWithContentsDto>()
-      .returnResult()
-      .responseBody
-
-    assertThat(questionsGroup?.groupId).isEqualTo(UUID.fromString(groupUuid))
-
-    val questionRefs = questionsGroup?.contents
-    val questionRef = questionRefs?.get(0) as GroupQuestionDto
-    assertThat(questionRef.questionId).isEqualTo(UUID.fromString(questionSchemaUuid))
-
-    val answerSchemaUuids = questionRef.answerSchemas?.map { it.answerSchemaUuid }
-    assertThat(answerSchemaUuids).contains(UUID.fromString(answerSchemaUuid))
+    val subGroup = questionRefs?.last() as GroupWithContentsDto
+    assertThat(subGroup.groupId).isEqualTo(UUID.fromString(subgroupUuid))
+    assertThat(subGroup.contents.size).isEqualTo(1)
+    val subQuestion = subGroup.contents.first() as GroupQuestionDto
+    assertThat(subQuestion.questionId).isEqualTo(UUID.fromString(subquestionUuid))
   }
 
   @Test
@@ -128,13 +117,13 @@ class QuestionControllerTest : IntegrationTest() {
       .returnResult()
       .responseBody
 
-    assertThat(groupSummaries).hasSize(1)
+    assertThat(groupSummaries).hasSize(3)
 
     val groupInfo = groupSummaries?.first()
 
     assertThat(groupInfo?.groupId).isEqualTo(UUID.fromString(groupUuid))
     assertThat(groupInfo?.title).isEqualTo("Heading 1")
-    assertThat(groupInfo?.contentCount).isEqualTo(2)
+    assertThat(groupInfo?.contentCount).isEqualTo(3)
     assertThat(groupInfo?.groupCount).isEqualTo(0)
     assertThat(groupInfo?.questionCount).isEqualTo(2)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -137,6 +137,21 @@ class QuestionControllerTest : IntegrationTest() {
       .expectBody<GroupWithContentsDto>()
       .returnResult()
       .responseBody
+
+    assertThat(assessmentGroup.groupId).isEqualTo(UUID.fromString(assessmentGroupUuid))
+
+    val sections = assessmentGroup.contents
+    assertThat(sections.size).isEqualTo(1)
+
+    val section = sections.first() as GroupWithContentsDto
+    assertThat(section.groupId).isEqualTo(UUID.fromString(groupUuid))
+
+    val subsections = section.contents
+    assertThat(subsections.size).isEqualTo(1)
+
+    val subsection = subsections.first() as GroupWithContentsDto
+    assertThat(subsection.groupId).isEqualTo(UUID.fromString(subgroupUuid))
+    assertThat(subsection.contents.size).isEqualTo(0)
   }
 
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 @AutoConfigureWebTestClient
 class QuestionControllerTest : IntegrationTest() {
 
-  private val assessmentUuid = "e964d699-cf96-4abd-af0e-ddf1f6687a46"
+  private val assessmentGroupUuid = "e964d699-cf96-4abd-af0e-ddf1f6687a46"
   private val groupUuid = "e353f3df-113d-401c-a3c0-14239fc17cf9"
   private val subgroupUuid = "6afbe596-9956-4620-824b-c6c9000ace7c"
   private val questionSchemaUuid = "fd412ca8-d361-47ab-a189-7acb8ae0675b"
@@ -127,4 +127,16 @@ class QuestionControllerTest : IntegrationTest() {
     assertThat(groupInfo?.groupCount).isEqualTo(0)
     assertThat(groupInfo?.questionCount).isEqualTo(2)
   }
+
+  @Test
+  fun `section for top-level group by uuid`() {
+    val assessmentGroup = webTestClient.get().uri("/sections/$assessmentGroupUuid")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<GroupWithContentsDto>()
+      .returnResult()
+      .responseBody
+  }
+
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/QuestionControllerTest.kt
@@ -127,7 +127,7 @@ class QuestionControllerTest : IntegrationTest() {
 
   @Test
   fun `section for top-level group by uuid`() {
-    val assessmentGroup = webTestClient.get().uri("/sections/$assessmentGroupUuid")
+    val assessmentGroup = webTestClient.get().uri("/questions/$assessmentGroupUuid/summary")
       .headers(setAuthorisation())
       .exchange()
       .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/repositories/QuestionGroupRepositoryTest.kt
@@ -21,7 +21,7 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
   @Test
   fun `fetch group contents`() {
     val questionGroupEntities = questionGroupRepository.findByGroupGroupUuid(groupUuid)
-    assertThat(questionGroupEntities).hasSize(2)
+    assertThat(questionGroupEntities).hasSize(3)
 
     val questionGroupEntity = questionGroupEntities!!.first()
     assertThat(questionGroupEntity.contentType).isEqualTo("question")
@@ -31,13 +31,13 @@ class QuestionGroupRepositoryTest(@Autowired val questionGroupRepository: Questi
   @Test
   fun `list group summaries`() {
     val groupSummaries = questionGroupRepository.listGroups()
-    assertThat(groupSummaries).hasSize(1)
+    assertThat(groupSummaries).hasSize(3)
 
     val groupInfo = groupSummaries.first()
 
     assertThat(groupInfo.groupUuid).isEqualTo(groupUuid.toString())
     assertThat(groupInfo.heading).isEqualTo("Heading 1")
-    assertThat(groupInfo.contentCount).isEqualTo(2)
+    assertThat(groupInfo.contentCount).isEqualTo(3)
     assertThat(groupInfo.groupCount).isEqualTo(0)
     assertThat(groupInfo.questionCount).isEqualTo(2)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
@@ -97,7 +97,7 @@ class QuestionServiceTest {
     every { groupRepository.findByGroupUuid(groupUuid) } returns group
     every { dependencyService.dependencies() } returns QuestionDependencies(emptyList())
 
-    val groupQuestions = questionService.getQuestionGroup(groupUuid)
+    val groupQuestions = questionService.getGroupContents(groupUuid)
 
     assertThat(groupQuestions.groupId).isEqualTo(groupUuid)
 

--- a/src/test/resources/referenceData/before-test.sql
+++ b/src/test/resources/referenceData/before-test.sql
@@ -19,7 +19,8 @@ INSERT INTO question_schema (question_schema_id, question_schema_uuid, question_
 VALUES (0, 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'RSR_01', 'RSR_01', '2019-11-14 08:11:53.177108', null, 'radio', 'f756f79d-dfad-49f9-a1b9-964a41cf660d', 'Question text', 'Help text'),
        (1, '1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'RSR_01_conditional', 'RSR_01_conditional', '2019-11-14 08:11:53.177108', null, 'freetext', null, 'Question text', 'Help text'),
        (2, 'a5830801-533c-4b9e-bab1-03272718d6dc', 'OASys_mapped', 'ignored', '2019-11-14 08:11:53.177108', null, 'freetext', null, 'Question text', 'Help text'),
-       (3, 'a8e303f5-5f88-4343-94d1-a369ca1f86cb', 'OASys_mapped_to_fixed', 'ignored', '2019-11-14 08:11:53.177108', null, 'freetext', null, 'Question text', 'Help text');
+       (3, 'a8e303f5-5f88-4343-94d1-a369ca1f86cb', 'OASys_mapped_to_fixed', 'ignored', '2019-11-14 08:11:53.177108', null, 'freetext', null, 'Question text', 'Help text'),
+       (4, 'b9dd3680-c4d6-403e-8f27-8d65481cbf44', 'RSR_02', 'RSR_02', '2019-11-14 08:11:53.177108', null, 'freetext', null, 'Question text', 'Help text');
 
 INSERT INTO oasys_question_mapping(mapping_id, mapping_uuid, question_schema_uuid, ref_section_code, logical_page, ref_question_code)
 VALUES (99, '204b461b-90af-4e11-b57f-7ccb07b67059', 'a5830801-533c-4b9e-bab1-03272718d6dc', 'RSR', '1', 'RSR_02');
@@ -29,11 +30,17 @@ VALUES (97, '5bfbc30d-811f-443e-8f82-8d86eaadbbe4', 'a8e303f5-5f88-4343-94d1-a36
 
 
 INSERT INTO grouping (group_id, group_uuid, group_code, heading, subheading, help_text, group_start, group_end)
-VALUES (0, 'e353f3df-113d-401c-a3c0-14239fc17cf9', 'Group code', 'Heading 1', 'Subheading 1', 'Help text', '2019-11-14 08:11:53.177108', null);
+VALUES (0, 'e964d699-cf96-4abd-af0e-ddf1f6687a46', 'assessment', 'Assessement', 'Subheading 1', 'Help text', '2019-11-14 08:11:53.177108', null),
+       (1, 'e353f3df-113d-401c-a3c0-14239fc17cf9', 'Group code', 'Heading 1', 'Subheading 1', 'Help text', '2019-11-14 08:11:53.177108', null),
+       (2, '6afbe596-9956-4620-824b-c6c9000ace7c', 'Subgroup code', 'Second level heading', '', '', '2019-11-14 08:11:53.177108', null);
+
 
 INSERT INTO question_group (question_group_id, question_group_uuid, content_uuid, content_type, group_uuid, display_order, mandatory, validation)
 VALUES (0, '334f3e21-b249-4c7f-848e-05c0d2aad8f4', 'fd412ca8-d361-47ab-a189-7acb8ae0675b', 'question', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '1', true, null ),
-       (1, 'fcec5c32-ea96-424c-80a5-8186dc414619', '1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'question', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '2', false, null );
+       (1, 'fcec5c32-ea96-424c-80a5-8186dc414619', '1948af63-07f2-4a8c-9e4c-0ec347bd6ba8', 'question', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '2', false, null ),
+       (2, 'c1d9281d-2363-43a7-9e02-bd19c13d685f', 'e353f3df-113d-401c-a3c0-14239fc17cf9', 'group', 'e964d699-cf96-4abd-af0e-ddf1f6687a46', '1', false, null ),
+       (3, '67b942c8-86f6-4493-af53-9f814b41f344', '6afbe596-9956-4620-824b-c6c9000ace7c', 'group', 'e353f3df-113d-401c-a3c0-14239fc17cf9', '3', false, null ),
+       (4, '6c0c874f-cd71-4422-b153-2cb270183b5c', 'b9dd3680-c4d6-403e-8f27-8d65481cbf44', 'question', '6afbe596-9956-4620-824b-c6c9000ace7c', '3', false, null );
 
 /* Question Dependency */
 insert into question_dependency (subject_question_uuid, trigger_question_uuid, trigger_answer_value, dependency_start, display_inline)


### PR DESCRIPTION
New endpoint `/questions/{groupCode}/summary`giving abbreviated group and subgroup information. This is used in the front-end to build the task list. 
```
{
  "groupId": "65a3924c-4130-4140-b7f4-cc39a52603bb",
  "groupCode": "pre_sentence_assessment",
  "title": "Pre-Sentence Assessment",
  "contents": [
    {
      "groupId": "d2215d25-7664-4d24-9efe-23ea65a6aa70",
      "groupCode": "offending_information_the_individual_",
      "title": "Offending Information (The individual)",
      "contents":  [
        {
          "groupId": "....",
          "groupCode": "....",
          "title": "Main offence",
        },
        {
          "groupId": "....",
          "groupCode": "....",
          "title": "Bonus offence",
        }
      ]
    },
    {
      "groupId": "c1a3c565-f4c3-4a84-af5d-e4159cce679b",
      "groupCode": "assessment_details_psr_metadata_",
      "title": "Assessment Details (PSR metadata)",
      "contents": [ ]
    },
    ...
```
Should we need to add status information later, we can extend this to take an episode UUID too. 