### PR TITLE
:alien: Add Validation errors collection to UpdateAssessmentAnswersRe…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessmentupdateapi/UpdateAssessmentAnswersResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessmentupdateapi/UpdateAssessmentAnswersResponseDto.kt
@@ -1,3 +1,3 @@
 package uk.gov.justice.digital.assessments.restclient.assessmentupdateapi
 
-data class UpdateAssessmentAnswersResponseDto(val oasysSetPk: Long? = null, val validationErrors: String? = null)
+data class UpdateAssessmentAnswersResponseDto(val oasysSetPk: Long? = null, val validationErrorDtos: Set<ValidationErrorDto> = emptySet())

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessmentupdateapi/ValidationErrorDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessmentupdateapi/ValidationErrorDto.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.assessments.restclient.assessmentupdateapi
+
+class ValidationErrorDto(
+  val sectionCode: String? = null,
+  val logicalPage: Long? = null,
+  val questionCode: String? = null,
+  val errorCode: String? = null,
+  val message: String? = null,
+  val assessmentValidationError: Boolean? = true
+)


### PR DESCRIPTION
This updates the DTO returned by the update service with validation errors. It should be merged after this PR https://github.com/ministryofjustice/offender-assessments-updates/pull/25 to avoid a breaking change.