### PR TITLE
Arn 340 passing validation errors up to the front-end from OASys

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
@@ -29,7 +29,10 @@ class AssessmentEpisodeDto(
   val ended: LocalDateTime? = null,
 
   @Schema(description = "Answers associated with this episode")
-  val answers: Map<UUID, Collection<String>> = emptyMap()
+  val answers: Map<UUID, Collection<String>> = emptyMap(),
+
+  @Schema(description = "Validation errors on this episode, indexed by question UUID")
+  val errors: Map<UUID, Collection<String>>? = null
 ) {
   companion object {
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
@@ -40,7 +40,7 @@ class AssessmentEpisodeDto(
       return episodes.mapNotNull { from(it) }.toSet()
     }
 
-    fun from(episode: AssessmentEpisodeEntity): AssessmentEpisodeDto {
+    fun from(episode: AssessmentEpisodeEntity, errors: Map<UUID, Collection<String>>? = null): AssessmentEpisodeDto {
       return AssessmentEpisodeDto(
         episode.episodeId,
         episode.episodeUuid,
@@ -49,7 +49,8 @@ class AssessmentEpisodeDto(
         episode.changeReason,
         episode.createdDate,
         episode.endDate,
-        AnswerDto.from(episode.answers) ?: emptyMap()
+        AnswerDto.from(episode.answers) ?: emptyMap(),
+        errors
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
@@ -4,11 +4,9 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
 import uk.gov.justice.digital.assessments.api.AssessmentDto
 import uk.gov.justice.digital.assessments.api.AssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.api.AssessmentSubjectDto
@@ -96,8 +94,10 @@ class AssessmentController(val assessmentService: AssessmentService) {
     @Parameter(description = "Assessment UUID", required = true, example = "1234") @PathVariable assessmentUuid: UUID,
     @Parameter(description = "Episode UUID", required = true) @PathVariable episodeUuid: UUID,
     @Parameter(description = "Episode Answers", required = true) @RequestBody episodeAnswers: UpdateAssessmentEpisodeDto
-  ): AssessmentEpisodeDto? {
-    return assessmentService.updateEpisode(assessmentUuid, episodeUuid, episodeAnswers)
+  ): ResponseEntity<AssessmentEpisodeDto> {
+    return updateResponse(
+      assessmentService.updateEpisode(assessmentUuid, episodeUuid, episodeAnswers)
+    )
   }
 
   @RequestMapping(path = ["/assessments/{assessmentUuid}/episodes/current"], method = [RequestMethod.POST])
@@ -111,7 +111,16 @@ class AssessmentController(val assessmentService: AssessmentService) {
   fun updateAssessmentEpisode(
     @Parameter(description = "Assessment UUID", required = true, example = "1234") @PathVariable assessmentUuid: UUID,
     @Parameter(description = "Episode Answers", required = true) @RequestBody episodeAnswers: UpdateAssessmentEpisodeDto
-  ): AssessmentEpisodeDto? {
-    return assessmentService.updateCurrentEpisode(assessmentUuid, episodeAnswers)
+  ): ResponseEntity<AssessmentEpisodeDto> {
+    return updateResponse(
+      assessmentService.updateCurrentEpisode(assessmentUuid, episodeAnswers)
+    )
+  }
+
+  private fun updateResponse(
+    assessmentEpisode: AssessmentEpisodeDto
+  ): ResponseEntity<AssessmentEpisodeDto> {
+    val code = if (assessmentEpisode.errors == null) HttpStatus.OK else HttpStatus.UNPROCESSABLE_ENTITY
+    return ResponseEntity(assessmentEpisode, code)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -205,6 +205,22 @@ class AssessmentService(
   ): AssessmentEpisodeDto {
     if (episode.isClosed()) throw UpdateClosedEpisodeException("Cannot update closed Episode ${episode.episodeUuid} for assessment ${episode.assessment?.assessmentUuid}")
 
+    updateEpisodeAnswers(episode, updatedEpisodeAnswers)
+    log.info("Updated episode ${episode.episodeUuid} with ${updatedEpisodeAnswers.answers.size} answer(s) for assessment ${episode.assessment?.assessmentUuid}")
+
+    updateOASysAssessment(episode.assessment?.subject?.oasysOffenderPk, episode)
+    log.info("Updated OASys ${episode.assessment?.subject?.oasysOffenderPk} with ${updatedEpisodeAnswers.answers.size} answer(s) for assessment ${episode.assessment?.assessmentUuid}")
+
+    assessmentRepository.save(episode.assessment)
+    log.info("Saved episode ${episode.episodeUuid} for assessment ${episode.assessment?.assessmentUuid}")
+
+    return AssessmentEpisodeDto.from(episode)
+  }
+
+  private fun updateEpisodeAnswers(
+    episode: AssessmentEpisodeEntity,
+    updatedEpisodeAnswers: UpdateAssessmentEpisodeDto
+  ) {
     for (updatedAnswer in updatedEpisodeAnswers.answers) {
       val currentQuestionAnswer = episode.answers?.get(updatedAnswer.key)
 
@@ -217,11 +233,6 @@ class AssessmentService(
         currentQuestionAnswer.answers = updatedAnswer.value
       }
     }
-    log.info("Updated episode ${episode.episodeUuid} with ${updatedEpisodeAnswers.answers.size} answer(s) for assessment ${episode.assessment?.assessmentUuid}")
-
-    updateOASysAssessment(episode.assessment?.subject?.oasysOffenderPk, episode)
-
-    return AssessmentEpisodeDto.from(episode)
   }
 
   fun updateOASysAssessment(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -281,16 +281,7 @@ class AssessmentService(
   ): Map<UUID, Collection<String>>? {
     if (oasysUpdateResult == null || oasysUpdateResult.validationErrorDtos.isEmpty())
       return null
-/*
-class ValidationErrorDto(
-  val sectionCode: String? = null,
-  val logicalPage: Long? = null,
-  val questionCode: String? = null,
-  val errorCode: String? = null,
-  val message: String? = null,
-  val assessmentValidationError: Boolean? = true
-)
- */
+
     val questionsInThisEpisode = episode.answers?.keys ?: emptySet()
 
     val mappedErrors = mutableMapOf<UUID, Collection<String>>()

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
@@ -16,7 +16,7 @@ class EpisodeService(
   private val courtCaseRestClient: CourtCaseRestClient
 ) {
   fun prepopulate(episode: AssessmentEpisodeEntity): AssessmentEpisodeEntity {
-    val questionsToPopulate = questionService.getAllQuestions().filter { it.externalSource != null }
+    val questionsToPopulate = questionService.getAllQuestions().withExternalSource()
     if (questionsToPopulate.isEmpty())
       return episode
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/AssessmentDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/AssessmentDtoTest.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
-@DisplayName("Assessment DTO Tests")
 class AssessmentDtoTest {
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDtoTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import java.time.LocalDateTime
 import java.util.UUID
 
-@DisplayName("Assessment DTO Tests")
 class AssessmentEpisodeDtoTest {
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/QuestionSchemaDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/QuestionSchemaDtoTest.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.assessments.jpa.entities.QuestionSchemaEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
-@DisplayName("Assessment DTO Tests")
 class QuestionSchemaDtoTest {
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import uk.gov.justice.digital.assessments.api.AnswerDto
 import uk.gov.justice.digital.assessments.api.CreateAssessmentDto
 import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerEntity
@@ -241,6 +240,7 @@ class AssessmentServiceTest {
         mapOf(newQuestionUuid to listOf("trousers")))
 
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
+      every { assessmentRepository.save(any()) } returns null
 
       val episodeDto = assessmentsService.updateEpisode(assessmentUuid, episodeUuid, updatedAnswers)
 
@@ -268,6 +268,7 @@ class AssessmentServiceTest {
       )
 
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
+      every { assessmentRepository.save(any()) } returns null
 
       val episodeDto = assessmentsService.updateEpisode(assessmentUuid, episodeUuid, updatedAnswers)
 
@@ -290,6 +291,7 @@ class AssessmentServiceTest {
       )
 
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
+      every { assessmentRepository.save(any()) } returns null
 
       val episodeDto = assessmentsService.updateEpisode(assessmentUuid, episodeUuid, updatedAnswers)
 
@@ -435,7 +437,6 @@ class AssessmentServiceTest {
 
     @Test
     fun `only fetch coded answers`() {
-
       setupQuestionCodes()
 
       val assessment = AssessmentEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundExce
 import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
-@DisplayName("Assessment Service Tests")
+@DisplayName("Offender Service Tests")
 class OffenderServiceTest {
 
   private val communityApiRestClient: CommunityApiRestClient = mockk()


### PR DESCRIPTION
:sparkles: Down in the AssessmentService, picks up any validation errors passed back from OASys, maps them back into the ARN question ids and passes them back up in the AssessmentEpisodeDto. When we implement validation in ARN we apply them in the same place in the code, and in the same way. 

:construction: (Section and assessment level errors are currently ignored, nor is there any translation of the OASys errors to our friendlier language.)

:bug: Save the updated episode back to our database.

:art: QuestionService.getAllQuestions() now returns QuestionSchemaEntities, rather than a naked list. This is a little shim which helps with mapping to and from OASys, and one or two other little things.
