### PR TITLE
Post Show'n'Tell tidy up

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentAnswersDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentAnswersDto.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.assessments.api
 import java.util.UUID
 
 data class AssessmentAnswersDto(
-
   val assessmentUuid: UUID,
   // Question Code -> List Of Answer Schema Dto
   val answers: Map<String, Collection<AnswerSchemaDto>>

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.assessments.api
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
+import uk.gov.justice.digital.assessments.services.dto.AssessmentEpisodeUpdateErrors
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -44,8 +45,7 @@ class AssessmentEpisodeDto(
 
     fun from(
       episode: AssessmentEpisodeEntity,
-      errors: Map<UUID, Collection<String>>? = null,
-      pageErrors: Collection<String>? = null
+      errors: AssessmentEpisodeUpdateErrors? = null,
     ): AssessmentEpisodeDto {
       return AssessmentEpisodeDto(
         episode.episodeId,
@@ -56,8 +56,8 @@ class AssessmentEpisodeDto(
         episode.createdDate,
         episode.endDate,
         AnswerDto.from(episode.answers) ?: emptyMap(),
-        errors,
-        pageErrors
+        errors?.errors,
+        errors?.pageErrors
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/AssessmentEpisodeUpdateErrors.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/AssessmentEpisodeUpdateErrors.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.assessments.services.dto
+
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
+import uk.gov.justice.digital.assessments.services.QuestionSchemaEntities
+import java.util.*
+
+class AssessmentEpisodeUpdateErrors (
+  private val answerErrors: MutableMap<UUID, MutableCollection<String>> = mutableMapOf(),
+  private val errorsOnPage: MutableList<String> = mutableListOf()
+){
+  val errors: Map<UUID, Collection<String>>?
+    get() = if (answerErrors.isNotEmpty()) answerErrors else null
+  val pageErrors: Collection<String>?
+    get() = if (errorsOnPage.isNotEmpty()) errorsOnPage else null
+
+  private fun addAnswerError(question: UUID, message: String?) {
+    answerErrors.putIfAbsent(question, mutableListOf())
+    answerErrors[question]?.add(message ?: "Field validation error")
+  }
+
+  private fun addPageError(message: String?) {
+    errorsOnPage.add(message ?: "Error on page")
+  }
+
+  companion object {
+    fun mapOasysErrors(
+      episode: AssessmentEpisodeEntity,
+      questions: QuestionSchemaEntities,
+      oasysUpdateResult: UpdateAssessmentAnswersResponseDto?
+    ): AssessmentEpisodeUpdateErrors? {
+      if (oasysUpdateResult == null || oasysUpdateResult.validationErrorDtos.isEmpty())
+        return null
+
+      val updateErrors = AssessmentEpisodeUpdateErrors()
+
+      mapAnswerErrors(updateErrors, episode, questions, oasysUpdateResult)
+      mapPageErrors(updateErrors, oasysUpdateResult)
+
+      return updateErrors
+    }
+
+    private fun mapAnswerErrors(
+      updateErrors: AssessmentEpisodeUpdateErrors,
+      episode: AssessmentEpisodeEntity,
+      questions: QuestionSchemaEntities,
+      oasysUpdateResult: UpdateAssessmentAnswersResponseDto
+    ) {
+      val questionsInThisEpisode = episode.answers?.keys ?: emptySet()
+
+      oasysUpdateResult.validationErrorDtos.forEach {
+        val mappedQuestions = questions.forOasysMapping(it.sectionCode, it.logicalPage, it.questionCode)
+        mappedQuestions
+          .filter { q -> questionsInThisEpisode.contains(q.questionSchemaUuid) }
+          .forEach { q -> updateErrors.addAnswerError(q.questionSchemaUuid, it.message) }
+      }
+    } // mapAnswerErrors
+
+    private fun mapPageErrors(
+      updateErrors: AssessmentEpisodeUpdateErrors,
+      oasysUpdateResult: UpdateAssessmentAnswersResponseDto
+    ) {
+      oasysUpdateResult.validationErrorDtos
+        .filter { it.questionCode == null }
+        .forEach { updateErrors.addPageError(it.message) }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.assessments.services.dto
+
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
+import uk.gov.justice.digital.assessments.jpa.entities.OASysMappingEntity
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
+import uk.gov.justice.digital.assessments.services.AssessmentService
+import uk.gov.justice.digital.assessments.services.QuestionSchemaEntities
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class OasysAnswers(
+  private val allAnswers: MutableSet<OasysAnswer> = mutableSetOf()
+): Set<OasysAnswer> by allAnswers {
+  private fun addAll(answers: Collection<OasysAnswer>) {
+    allAnswers.addAll(answers)
+  }
+
+  companion object {
+    fun from(
+      episode: AssessmentEpisodeEntity,
+      questions: QuestionSchemaEntities
+    ): OasysAnswers {
+      val oasysAnswers = OasysAnswers()
+
+      // TODO: If we want to handle multiple mappings per question we will need to add assessment type to the mapping
+      episode.answers?.forEach { episodeAnswer ->
+        val question = questions[episodeAnswer.key]
+        val oasysMapping = question?.oasysMappings?.toList()?.getOrNull(0)
+        oasysAnswers.addAll(
+          mapOasysAnswer(
+            oasysMapping,
+            episodeAnswer.value.answers,
+            question?.answerType)
+        )
+      }
+
+      return oasysAnswers
+    }
+
+    fun mapOasysAnswer(
+      oasysMapping: OASysMappingEntity?,
+      answers: Collection<String>,
+      answerType: String?
+    ): List<OasysAnswer> {
+      if (oasysMapping == null) return emptyList()
+
+      return answers.map { it ->
+        val answer = when (answerType) {
+          "date" -> toOASysDate(it)
+          else -> it
+        }
+
+        OasysAnswer(
+          oasysMapping.sectionCode,
+          oasysMapping.logicalPage,
+          oasysMapping.questionCode,
+          answer,
+          oasysMapping.isFixed
+        )
+      }.toList()
+    }
+
+    private fun toOASysDate(dateStr: String): String {
+      if (dateStr.length < 10)
+        return dateStr
+      return LocalDate.parse(dateStr.substring(0, 10), DateTimeFormatter.ISO_DATE).format(oasysDateFormatter)
+    }
+
+    val oasysDateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -25,9 +25,11 @@ import uk.gov.justice.digital.assessments.jpa.repositories.AssessmentRepository
 import uk.gov.justice.digital.assessments.jpa.repositories.SubjectRepository
 import uk.gov.justice.digital.assessments.restclient.AssessmentUpdateRestClient
 import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.ValidationErrorDto
 import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
+import uk.gov.justice.digital.assessments.services.dto.OasysAnswers
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.UpdateClosedEpisodeException
 import java.time.LocalDateTime
@@ -601,7 +603,7 @@ class AssessmentServiceTest {
 
       val answerSchema = AnswerSchemaEntity(value = "YES", answerSchemaId = 1, answerSchemaUuid = answer1Uuid, answerSchemaCode = "A1", answerSchemaGroup = AnswerSchemaGroupEntity(answerSchemaId = 1, answerSchemaGroupUuid = UUID.randomUUID()))
       val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
-      val result = assessmentsService.mapOasysAnswer(mapping, listOf("Free Text"), "radios")[0]
+      val result = OasysAnswers.mapOasysAnswer(mapping, listOf("Free Text"), "radios")[0]
       assertThat(result.answer).isEqualTo("Free Text")
       assertThat(result.logicalPage).isEqualTo(1)
       assertThat(result.isStatic).isFalse()
@@ -612,7 +614,7 @@ class AssessmentServiceTest {
     @Test
     fun `should create Oasys Answer with correct date format`() {
       val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
-      val result = assessmentsService.mapOasysAnswer(mapping, listOf("1975-01-20T00:00:00.000Z"), "date")[0]
+      val result = OasysAnswers.mapOasysAnswer(mapping, listOf("1975-01-20T00:00:00.000Z"), "date")[0]
       assertThat(result.answer).isEqualTo("20/01/1975")
     }
   }


### PR DESCRIPTION
Pull out a couple of helper objects for each direction across the OASys boundary. `OasysAnswers` wraps up everything going in, while `AssessmentEpisodeUpdateErrors` gathers up the answer level and page level validation errors that might be coming back. 

Introducing these objects avoids us handing round naked collections of strings (even if that's ultimately what we pass out through the controllers as JSON), and gathers the mapping code for each operation off by itself. 