### PR TITLE
:sparkles: add category codes and descriptions to offence details from community api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/OffenceDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/OffenceDto.kt
@@ -9,7 +9,12 @@ class OffenceDto(
   val convictionId: Long? = null,
   val convictionDate: LocalDate? = null,
   val mainOffenceId: String? = null,
-  val offenceCode: String? = null
+  val offenceCode: String? = null,
+  val offenceDescription: String? = null,
+  val categoryCode: String? = null,
+  val categoryDescription: String? = null,
+  val subCategoryCode: String? = null,
+  val subCategoryDescription: String? = null
 ) {
   companion object {
     fun from(convictionDto: CommunityConvictionDto): OffenceDto {
@@ -18,7 +23,12 @@ class OffenceDto(
         convictionId = convictionDto.convictionId,
         convictionDate = convictionDto.convictionDate,
         mainOffenceId = offence.offenceId,
-        offenceCode = offence.detail?.code
+        offenceCode = offence.detail?.code,
+        offenceDescription = offence.detail?.description,
+        categoryCode = offence.detail?.mainCategoryCode,
+        categoryDescription = offence.detail?.mainCategoryDescription,
+        subCategoryCode = offence.detail?.subCategoryCode,
+        subCategoryDescription = offence.detail?.subCategoryDescription
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/OffenceDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/OffenceDtoTest.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.assessments.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.assessments.restclient.communityapi.*
+import uk.gov.justice.digital.assessments.restclient.courtcaseapi.DefendantAddress
+import java.time.LocalDate
+
+@DisplayName("Offender DTO Tests")
+class OffenceDtoTest {
+
+  private val convictionDate: LocalDate = LocalDate.now()
+  @Test
+  fun `builds valid offender DTO from Community Offender`() {
+    val communityConvictionDto = CommunityConvictionDto(
+      convictionId = 1234L,
+      offences = listOf(
+        Offence(
+          offenceId = "offenceId",
+          mainOffence = true,
+          detail = OffenceDetail(
+            code = "offence code",
+            description = "offence description",
+            mainCategoryCode = "main category code",
+            mainCategoryDescription = "code description 1",
+            subCategoryCode = "subcategory code",
+            subCategoryDescription = "code description 2"
+          )
+        )
+      ),
+      convictionDate = convictionDate
+    )
+
+    val offenceDto = OffenceDto.from(communityConvictionDto)
+
+    assertThat(offenceDto.convictionId).isEqualTo(1234L)
+    assertThat(offenceDto.convictionDate).isEqualTo(convictionDate)
+    assertThat(offenceDto.mainOffenceId).isEqualTo("offenceId")
+    assertThat(offenceDto.offenceCode).isEqualTo("offence code")
+    assertThat(offenceDto.offenceDescription).isEqualTo("offence description")
+    assertThat(offenceDto.categoryCode).isEqualTo("main category code")
+    assertThat(offenceDto.categoryDescription).isEqualTo("code description 1")
+    assertThat(offenceDto.subCategoryCode).isEqualTo("subcategory code")
+    assertThat(offenceDto.subCategoryDescription).isEqualTo("code description 2")
+  }
+
+  @Test
+  fun `builds valid Address from Defendant address`() {
+    val defendantAddress = DefendantAddress(
+      line1 = "line1",
+      line2 = "line2",
+      line3 = "line3",
+      line4 = "line4",
+      line5 = "line5",
+      postcode = "postcode"
+    )
+
+    val address = Address.from(defendantAddress)
+
+    assertThat(address?.address1).isEqualTo(defendantAddress.line1)
+    assertThat(address?.address2).isEqualTo(defendantAddress.line2)
+    assertThat(address?.address3).isEqualTo(defendantAddress.line3)
+    assertThat(address?.address4).isEqualTo(defendantAddress.line4)
+    assertThat(address?.address5).isEqualTo(defendantAddress.line5)
+    assertThat(address?.postcode).isEqualTo(defendantAddress.postcode)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/OffenderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/OffenderControllerTest.kt
@@ -43,7 +43,7 @@ class OffenderControllerTest : IntegrationTest() {
   }
 
   @Test
-  fun `get offender returns offender with address for crn and conviction ID`() {
+  fun `returns offender with address`() {
     val offenderDto = webTestClient.get().uri("/offender/crn/$crn/conviction/$convictionId")
       .headers(setAuthorisation())
       .exchange()
@@ -58,7 +58,7 @@ class OffenderControllerTest : IntegrationTest() {
   }
 
   @Test
-  fun `get offender returns not found for invalid crn`() {
+  fun `returns not found for invalid crn`() {
     val invalidCrn = "invalid"
     webTestClient.get().uri("/offender/crn/$invalidCrn/conviction/$convictionId")
       .headers(setAuthorisation())
@@ -67,7 +67,7 @@ class OffenderControllerTest : IntegrationTest() {
   }
 
   @Test
-  fun `get offender returns offender with aliases for crn and conviction ID`() {
+  fun `returns offender with aliases`() {
     val offenderDto = webTestClient.get().uri("/offender/crn/$crn/conviction/$convictionId")
       .headers(setAuthorisation())
       .exchange()
@@ -79,5 +79,24 @@ class OffenderControllerTest : IntegrationTest() {
     assertThat(offenderDto?.offenderId).isEqualTo(oasysUserId)
     assertThat(offenderDto?.firstNameAliases).containsOnly("John", "Jonny")
     assertThat(offenderDto?.surnameAliases).containsOnly("Smithy")
+  }
+
+  @Test
+  fun `returns offence with category codes and code descriptions`() {
+    val offenderDto = webTestClient.get().uri("/offender/crn/$crn/conviction/$convictionId")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<OffenderDto>()
+      .returnResult()
+      .responseBody
+
+    assertThat(offenderDto?.offenderId).isEqualTo(oasysUserId)
+    assertThat(offenderDto?.offence?.offenceCode).isEqualTo("code1")
+    assertThat(offenderDto?.offence?.offenceDescription).isEqualTo("Offence description")
+    assertThat(offenderDto?.offence?.categoryCode).isEqualTo("cat1")
+    assertThat(offenderDto?.offence?.categoryDescription).isEqualTo("category description 1")
+    assertThat(offenderDto?.offence?.subCategoryCode).isEqualTo("cat2")
+    assertThat(offenderDto?.offence?.subCategoryDescription).isEqualTo("category description 2")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
@@ -38,7 +38,7 @@ class OffenderServiceTest {
   private val convictionId = 636401162L
 
   @Test
-  fun `should return offender if one exists`() {
+  fun `return offender`() {
     every { communityApiRestClient.getOffender(crn) } returns validCommunityOffenderDto()
 
     val offenderDto = offenderService.getOffender(crn)
@@ -47,19 +47,19 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `should return offence if one exists`() {
+  fun `return offence`() {
     every { communityApiRestClient.getConviction(crn, convictionId) } returns validCommunityConvictionDto()
 
     val offenceDto = offenderService.getOffence(crn, convictionId)
     assertThat(offenceDto.convictionId).isEqualTo(convictionId)
     assertThat(offenceDto.mainOffenceId).isEqualTo("offence1")
-    assertThat(offenceDto.offenceCode).isEqualTo("code1")
+    assertThat(offenceDto.offenceCode).isEqualTo("offence code")
 
     verify(exactly = 1) { communityApiRestClient.getConviction(any(), any()) }
   }
 
   @Test
-  fun `should return offender and offence if they exist`() {
+  fun `return offender and offence`() {
     every { communityApiRestClient.getOffender(crn) } returns validCommunityOffenderDto()
     every { communityApiRestClient.getConviction(crn, convictionId) } returns validCommunityConvictionDto()
     every { subjectRepository.findAllByCrnAndSourceOrderByCreatedDateDesc(crn, "COURT") } returns validCourtSubject()
@@ -70,13 +70,13 @@ class OffenderServiceTest {
     assertThat(offenderDto.offenderId).isEqualTo(oasysOffenderPk)
     assertThat(offenderDto.offence?.convictionId).isEqualTo(convictionId)
     assertThat(offenderDto.offence?.mainOffenceId).isEqualTo("offence1")
-    assertThat(offenderDto.offence?.offenceCode).isEqualTo("code1")
+    assertThat(offenderDto.offence?.offenceCode).isEqualTo("offence code")
     verify(exactly = 1) { communityApiRestClient.getOffender(any()) }
     verify(exactly = 1) { communityApiRestClient.getConviction(any(), any()) }
   }
 
   @Test
-  fun `should return offender with address if it exists`() {
+  fun `return offender with address`() {
     every { communityApiRestClient.getOffender(crn) } returns validCommunityOffenderDto()
     every { communityApiRestClient.getConviction(crn, convictionId) } returns validCommunityConvictionDto()
     every { subjectRepository.findAllByCrnAndSourceOrderByCreatedDateDesc(crn, "COURT") } returns validCourtSubject()
@@ -101,7 +101,7 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `should return court code and case number when they exist`() {
+  fun `return court code and case number`() {
     every { subjectRepository.findAllByCrnAndSourceOrderByCreatedDateDesc(crn, "COURT") } returns validCourtSubject()
 
     val courtSubject = offenderService.getCourtSubjectByCrn(crn)
@@ -122,7 +122,7 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `should return offender address when it exists`() {
+  fun `return offender address`() {
     every { subjectRepository.findAllByCrnAndSourceOrderByCreatedDateDesc(crn, "COURT") } returns validCourtSubject()
     every { courtCaseRestClient.getCourtCase("courtCode", "caseNumber") } returns validCourtCase()
     val address = offenderService.getOffenderAddress(crn)
@@ -134,7 +134,7 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `should return null offender address when none exist`() {
+  fun `return null offender address when none exist`() {
     every { subjectRepository.findAllByCrnAndSourceOrderByCreatedDateDesc(crn, "COURT") } returns validCourtSubject()
     every { courtCaseRestClient.getCourtCase("courtCode", "caseNumber") } returns CourtCase()
     val address = offenderService.getOffenderAddress(crn)
@@ -146,7 +146,7 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `should return offender with alias if it exists`() {
+  fun `return offender with alias`() {
     every { communityApiRestClient.getOffender(crn) } returns validCommunityOffenderDto()
     every { communityApiRestClient.getConviction(crn, convictionId) } returns validCommunityConvictionDto()
     every { subjectRepository.findAllByCrnAndSourceOrderByCreatedDateDesc(crn, "COURT") } returns validCourtSubject()
@@ -163,7 +163,7 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `should return empty offender aliases list when none exist`() {
+  fun `return empty offender aliases list when none exist`() {
     every { communityApiRestClient.getOffender(crn) } returns validCommunityOffenderDto().copy(offenderAliases = emptyList())
     every { communityApiRestClient.getConviction(crn, convictionId) } returns validCommunityConvictionDto()
     every { subjectRepository.findAllByCrnAndSourceOrderByCreatedDateDesc(crn, "COURT") } returns validCourtSubject()
@@ -177,6 +177,20 @@ class OffenderServiceTest {
     verify(exactly = 1) { courtCaseRestClient.getCourtCase(any(), any()) }
   }
 
+  @Test
+  fun `return offence with category codes and category descriptions`() {
+    every { communityApiRestClient.getConviction(crn, convictionId) } returns validCommunityConvictionDto()
+
+    val offenceDto = offenderService.getOffence(crn, convictionId)
+    assertThat(offenceDto.convictionId).isEqualTo(convictionId)
+    assertThat(offenceDto.offenceCode).isEqualTo("offence code")
+    assertThat(offenceDto.categoryCode).isEqualTo("main category code")
+    assertThat(offenceDto.categoryDescription).isEqualTo("code description 1")
+    assertThat(offenceDto.subCategoryCode).isEqualTo("subcategory code")
+    assertThat(offenceDto.subCategoryDescription).isEqualTo("code description 2")
+
+    verify(exactly = 1) { communityApiRestClient.getConviction(any(), any()) }
+  }
   private fun validCourtSubject(): List<SubjectEntity> {
     return listOf(SubjectEntity(sourceId = "courtCode|caseNumber"))
   }
@@ -202,8 +216,12 @@ class OffenderServiceTest {
           offenceId = "offence1",
           mainOffence = true,
           detail = OffenceDetail(
-            code = "code1",
-            description = "Offence description"
+            code = "offence code",
+            description = "Offence description",
+            mainCategoryCode = "main category code",
+            mainCategoryDescription = "code description 1",
+            subCategoryCode = "subcategory code",
+            subCategoryDescription = "code description 2"
           )
         ),
         Offence(
@@ -211,7 +229,11 @@ class OffenderServiceTest {
           mainOffence = false,
           detail = OffenceDetail(
             code = "code2",
-            description = "Offence description"
+            description = "Offence description",
+            mainCategoryCode = "main category code",
+            mainCategoryDescription = "code description 1",
+            subCategoryCode = "subcategory code",
+            subCategoryDescription = "code description 2"
           )
         )
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
@@ -96,7 +96,11 @@ class CommunityApiMockServer : WireMockServer(9096) {
           mainOffence = true,
           detail = OffenceDetail(
             code = "code1",
-            description = "Offence description"
+            description = "Offence description",
+            mainCategoryCode = "cat1",
+            mainCategoryDescription = "category description 1",
+            subCategoryCode = "cat2",
+            subCategoryDescription = "category description 2"
           )
         ),
         Offence(
@@ -104,7 +108,11 @@ class CommunityApiMockServer : WireMockServer(9096) {
           mainOffence = false,
           detail = OffenceDetail(
             code = "code2",
-            description = "Offence description"
+            description = "Offence description",
+            mainCategoryCode = "cat1",
+            mainCategoryDescription = "category description 1",
+            subCategoryCode = "cat2",
+            subCategoryDescription = "category description 2"
           )
         )
       ),


### PR DESCRIPTION
The offender/offence json now looks like this with the offence code and category codes with corresponding descriptions within the offence object.

```
{
  "offenderId": 101,
  "firstName": "John",
  "surname": "Smith",
  "dateOfBirth": "1979-08-18",
  "gender": "F",
  "crn": "DX12340A",
  "pncNumber": "A/1234560BA",
  "offence": {
    "convictionId": 636401162,
    "convictionDate": "2020-02-01",
    "mainOffenceId": "offence1",
    "offenceCode": "code1",
    "offenceDescription": "Offence description",
    "categoryCode": "cat1",
    "categoryDescription": "category description 1",
    "subCategoryCode": "cat2",
    "subCategoryDescription": "category description 2"
  },
  "address": {
    "address1": "38",
    "address2": "Clarendon Road",
    "address3": "Glasgow",
    "postcode": "ad21 5dr"
  },
  "firstNameAliases": [
    "John",
    "Jonny"
  ],
  "surnameAliases": [
    "Smithy"
  ]
}
```