### PR TITLE
Add reference data category to sources of information

### DIFF
--- a/psr/assessments/0001_reordered_short-form_psr_assessment_2-2_OASys_OGRS_and_RSR_only.csv
+++ b/psr/assessments/0001_reordered_short-form_psr_assessment_2-2_OASys_OGRS_and_RSR_only.csv
@@ -74,7 +74,7 @@ Psychiatric
 Psychology
 Request for information
 Victim statement
-Other",,None,,ID.45,"Each individual source held, sources_information_pivot.sources_information_ELM",,,,N,Q,Information sources,x,PROPIN/sources_info,
+Other",SOURCES_OF_INFORMATION,None,,ID.45,"Each individual source held, sources_information_pivot.sources_information_ELM",,,,N,Q,Information sources,x,PROPIN/sources_info,
 Give details,299.1,,,,,,X,N/A,Give details,,,,Consistency,textarea,,None,Static free text box with 4000 character limit,ID.46,sources_info_other_ftxt,,,,N,Q,Information sources,x,PROPIN/sources_other_text,
 "Offences, convictions and needs",S3,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Offences and convictions,S3.1,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/src/main/resources/db/migration/V1_7__presentence_report.sql
+++ b/src/main/resources/db/migration/V1_7__presentence_report.sql
@@ -147,7 +147,7 @@ VALUES ('1ea17930-d467-44c0-9e72-517747618acb', 'ui3.1', null, '2020-11-30 14:50
        ('d9ca82ca-8684-49e4-b7eb-91fb0effed91', '33.1', 'oasys_signing table', '2020-11-30 14:50:00', null, 'freetext', null, 'Signing history', null, null, null),
        ('eef973e6-f493-4460-b094-2162fc8dc7e9', '24.1', 'NOT HELD', '2020-11-30 14:50:00', null, 'date', null, 'Date report completed and signed', null, null, null),
        ('c2cb3e8b-a544-4b72-a533-223498fcb986', 'ui24.1', null, '2020-11-30 14:50:00', null, 'presentation: link("/update-assessment")', null, 'Update assessment details', null, null, null),
-       ('2b93527c-a545-4e41-9fb4-98ee127af393', '298.1', 'Each individual source held, sources_information_pivot.sources_information_ELM', '2020-11-30 14:50:00', null, 'checkbox', 'ee47fa78-eaba-421a-bcaf-0aea184dc5a3', 'Sources of information', null, null, null),
+       ('2b93527c-a545-4e41-9fb4-98ee127af393', '298.1', 'Each individual source held, sources_information_pivot.sources_information_ELM', '2020-11-30 14:50:00', null, 'checkbox', 'ee47fa78-eaba-421a-bcaf-0aea184dc5a3', 'Sources of information', null, null, 'SOURCES_OF_INFORMATION'),
        ('d9846a60-5ba6-450f-9934-2c9646771f9d', '299.1', 'sources_info_other_ftxt', '2020-11-30 14:50:00', null, 'textarea', null, 'Give details', null, null, null),
        ('0bc681b4-7f70-477e-8ef5-0daaf8aa0495', 'ui35.1.1', null, '2020-11-30 14:50:00', null, 'presentation: heading_large', null, 'PSR or Court considered offence ', 'Primary or most serious offence as judged by assessor', null, null),
        ('54b03faa-efc0-49ef-9add-7581dca17d70', '35.1.1', null, '2020-11-30 14:50:00', null, 'freetext', null, 'Offence', null, null, null),


### PR DESCRIPTION
### Context

This PR updates the migrations so that the `sources_of_information` field has the reference data category `SOURCES_OF_INFORMATION` for testing in Development