### PR TITLE
Table questions - children and victims

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/TableQuestionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/TableQuestionDto.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.assessments.api
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.assessments.jpa.entities.GroupEntity
+import uk.gov.justice.digital.assessments.jpa.entities.QuestionGroupEntity
+import java.util.UUID
+
+data class TableQuestionDto(
+  @Schema(description = "Table Identifier", example = "<uuid>")
+  val tableId: UUID,
+
+  @Schema(description = "Table Code", example = "table-code-name")
+  val tableCode: String,
+
+  @Schema(description = "Table Title", example = "Table of children")
+  val title: String? = null,
+
+  @Schema(description = "Table Subheading", example = "Some group subheading")
+  val subheading: String? = null,
+
+  @Schema(description = "Table Help-text", example = "Some group help text")
+  val helpText: String? = null,
+
+  @Schema(description = "Display Order for Table", example = "1")
+  val displayOrder: Int? = 0,
+
+  @Schema(description = "Table is Required", example = "true")
+  val mandatory: Boolean? = null,
+
+  @Schema(description = "Question Validation for Table", example = "to-do")
+  val validation: String? = null,
+
+  @Schema(description = "Questions and Groups")
+  val contents: List<GroupContentDto>
+) : GroupContentDto {
+  companion object {
+    fun from(group: GroupEntity, contents: List<GroupContentDto>, parentGroup: QuestionGroupEntity? = null): TableQuestionDto {
+      return TableQuestionDto(
+        tableId = group.groupUuid,
+        tableCode = group.groupCode,
+        title = group.heading,
+        subheading = group.subheading,
+        helpText = group.helpText,
+        displayOrder = parentGroup?.displayOrder,
+        mandatory = parentGroup?.mandatory,
+        validation = parentGroup?.validation,
+        contents = contents
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
@@ -65,17 +65,24 @@ class QuestionService(
     val contents = groupContents
       .map {
         when (it.contentType) {
-          "question" -> GroupQuestionDto.from(
-            questionSchemaRepository.findByQuestionSchemaUuid(it.contentUuid)!!,
-            it,
-            dependencies
-          )
+          "question" -> getGroupQuestion(it, dependencies)
           "group" -> getQuestionGroupContents(findByGroupUuid(it.contentUuid), it, dependencies)
           else -> throw EntityNotFoundException("Bad group content type")
         }
       }
 
     return GroupWithContentsDto.from(group, contents, parentGroup)
+  }
+
+  private fun getGroupQuestion(
+    question: QuestionGroupEntity,
+    dependencies: QuestionDependencies
+  ): GroupQuestionDto {
+    return GroupQuestionDto.from(
+      questionSchemaRepository.findByQuestionSchemaUuid(question.contentUuid)!!,
+      question,
+      dependencies
+    )
   }
 
   private fun fetchGroupSections(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
@@ -1,11 +1,7 @@
 package uk.gov.justice.digital.assessments.services
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.assessments.api.GroupQuestionDto
-import uk.gov.justice.digital.assessments.api.GroupSectionsDto
-import uk.gov.justice.digital.assessments.api.GroupSummaryDto
-import uk.gov.justice.digital.assessments.api.GroupWithContentsDto
-import uk.gov.justice.digital.assessments.api.QuestionSchemaDto
+import uk.gov.justice.digital.assessments.api.*
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaEntity
 import uk.gov.justice.digital.assessments.jpa.entities.GroupEntity
 import uk.gov.justice.digital.assessments.jpa.entities.QuestionGroupEntity
@@ -59,6 +55,23 @@ class QuestionService(
     parentGroup: QuestionGroupEntity?,
     dependencies: QuestionDependencies
   ): GroupWithContentsDto {
+    return expandGroupContents(group, parentGroup, dependencies, GroupWithContentsDto::from) as GroupWithContentsDto
+  }
+
+  private fun getTableGroupContents(
+    group: GroupEntity,
+    parentGroup: QuestionGroupEntity?,
+    dependencies: QuestionDependencies
+  ): TableQuestionDto {
+    return expandGroupContents(group, parentGroup, dependencies, TableQuestionDto::from) as TableQuestionDto
+  }
+
+  private fun expandGroupContents(
+    group: GroupEntity,
+    parentGroup: QuestionGroupEntity?,
+    dependencies: QuestionDependencies,
+    toDto: (GroupEntity, List<GroupContentDto>, QuestionGroupEntity?) -> GroupContentDto
+  ): GroupContentDto {
     val groupContents = group.contents.sortedBy { it.displayOrder }
     if (groupContents.isEmpty()) throw EntityNotFoundException("Questions not found for Group: ${group.groupUuid}")
 
@@ -71,18 +84,33 @@ class QuestionService(
         }
       }
 
-    return GroupWithContentsDto.from(group, contents, parentGroup)
+    return toDto(group, contents, parentGroup)
   }
+
 
   private fun getGroupQuestion(
     question: QuestionGroupEntity,
     dependencies: QuestionDependencies
-  ): GroupQuestionDto {
+  ): GroupContentDto {
+    val questionEntity = questionSchemaRepository.findByQuestionSchemaUuid(question.contentUuid)!!
+    if (questionEntity.answerType?.startsWith("table:") == true)
+      return tableGroupQuestion(questionEntity, dependencies)
     return GroupQuestionDto.from(
-      questionSchemaRepository.findByQuestionSchemaUuid(question.contentUuid)!!,
+      questionEntity,
       question,
       dependencies
     )
+  }
+
+  private fun tableGroupQuestion(
+    questionEntity: QuestionSchemaEntity,
+    dependencies: QuestionDependencies
+  ): TableQuestionDto {
+    val tableName = questionEntity.answerType?.split(":")?.get(1)
+      ?: throw EntityNotFoundException("Could not get table name for question ${questionEntity.questionCode}")
+    val tableGroup = groupRepository.findByGroupCode(tableName)
+      ?: throw EntityNotFoundException("Could not find group ${tableName} for question ${questionEntity.questionCode}")
+    return getTableGroupContents(tableGroup, null, dependencies)
   }
 
   private fun fetchGroupSections(

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.assessments.api.GroupQuestionDto
 import uk.gov.justice.digital.assessments.api.QuestionSchemaDto
+import uk.gov.justice.digital.assessments.api.TableQuestionDto
 import uk.gov.justice.digital.assessments.jpa.entities.GroupEntity
 import uk.gov.justice.digital.assessments.jpa.entities.GroupSummaryEntity
 import uk.gov.justice.digital.assessments.jpa.entities.QuestionGroupEntity
@@ -26,7 +27,6 @@ import java.util.UUID
 @ExtendWith(MockKExtension::class)
 @DisplayName("Question Schema Service Tests")
 class QuestionServiceTest {
-
   private val questionSchemaRepository: QuestionSchemaRepository = mockk()
   private val answerSchemaRepository: AnswerSchemaRepository = mockk()
   private val questionGroupRepository: QuestionGroupRepository = mockk()
@@ -56,9 +56,28 @@ class QuestionServiceTest {
     questionSchemaUuid = questionUuid
   )
 
+  private val groupWithTableUuid = UUID.randomUUID()
+  private val groupWithTableContents = mutableListOf<QuestionGroupEntity>()
+  private val groupWithTable = GroupEntity(
+    groupId = 9,
+    groupUuid = groupWithTableUuid,
+    groupCode = "group with table",
+    contents = groupWithTableContents
+  )
+
+  private val tableQuestionUuid = UUID.randomUUID()
+  private val tableQuestion = QuestionSchemaEntity(
+    questionSchemaId = 2L,
+    questionSchemaUuid = tableQuestionUuid,
+    answerType = "table:children"
+  )
+
+  private val tableSubQuestion1Id = UUID.randomUUID()
+  private val tableSubQuestion2Id = UUID.randomUUID()
+
   @BeforeEach
   fun setup() {
-    val questionGroup = QuestionGroupEntity(
+    contents.add(QuestionGroupEntity(
       questionGroupId = 99,
       group = group,
       contentUuid = questionUuid,
@@ -67,8 +86,30 @@ class QuestionServiceTest {
       question = question,
       nestedGroup = null,
       readOnly = false
-    )
-    contents.add(questionGroup)
+    ))
+
+    groupWithTableContents.add(QuestionGroupEntity(
+      questionGroupId = 99,
+      group = groupWithTable,
+      contentUuid = questionUuid,
+      contentType = "question",
+      displayOrder = 1,
+      question = question,
+      nestedGroup = null,
+      readOnly = false
+    ))
+    groupWithTableContents.add(QuestionGroupEntity(
+      questionGroupId = 99,
+      group = groupWithTable,
+      contentUuid = tableQuestionUuid,
+      contentType = "question",
+      displayOrder = 2,
+      question = tableQuestion,
+      nestedGroup = null,
+      readOnly = false
+    ))
+
+
   }
 
   @Test
@@ -106,6 +147,30 @@ class QuestionServiceTest {
     assertThat(groupContents).hasSize(1)
     val questionRef = groupContents[0] as GroupQuestionDto
     assertThat(questionRef.questionId).isEqualTo(questionUuid)
+  }
+
+  @Test
+  fun `get group contents with table`() {
+    every { groupRepository.findByGroupUuid(groupWithTableUuid) } returns groupWithTable
+    every { questionSchemaRepository.findByQuestionSchemaUuid(questionUuid) } returns question
+    every { questionSchemaRepository.findByQuestionSchemaUuid(tableQuestionUuid) } returns tableQuestion
+    every { dependencyService.dependencies() } returns QuestionDependencies(emptyList())
+
+    val groupQuestions = questionService.getGroupContents(groupWithTableUuid)
+
+    assertThat(groupQuestions.groupId).isEqualTo(groupWithTableUuid)
+
+    val groupContents = groupQuestions.contents
+    assertThat(groupContents).hasSize(2)
+
+    val questionRef = groupContents[0] as GroupQuestionDto
+    assertThat(questionRef.questionId).isEqualTo(questionUuid)
+
+    val tableRef = groupContents[1] as TableQuestionDto
+    assertThat(tableRef.tableId).isEqualTo(tableQuestionUuid)
+    assertThat(tableRef.contents).hasSize(2)
+    val tableQuestionIds = tableRef.contents.map { (it as GroupQuestionDto).questionId }
+    assertThat(tableQuestionIds).contains(tableSubQuestion1Id, tableSubQuestion2Id)
   }
 
   @Test


### PR DESCRIPTION
Working the shape of the questions JSON for tables - children, victims, etc. 

Questions JSON looks like this 
```
{
  "type": "group",
  "groupId": "65a3924c-4130-4140-b7f4-cc39a52603bb",
  "groupCode": "pre_sentence_assessment",
  "title": "Pre-Sentence Assessment",
  "contents": [
    { ... section ... },
    {
      "type": "group",
      "groupId": "1e1159e1-6092-4e22-9e29-5734654baeda",
      "groupCode": "rosh_screening",
      "title": "ROSH screening",
      "displayOrder": 4,
      "mandatory": true,
      "contents": [
        {
          "type": "group",
          "groupId": "946091d2-4038-4e2b-9283-83cc4876f6ed",
          "groupCode": "risk_to_others",
          "title": "Risk to others",
          "displayOrder": 1,
          "mandatory": true,
          "contents": [
            {
              "type": "question",
              "questionId": "5da33301-6e4e-4eb5-bf95-748494029669",
              "questionCode": "129.1",
              "answerType": "noinput",
              "questionText": "Has the individual been convicted of any of the following?",
              "helpText": "Select all that apply.",
              "displayOrder": 1,
              "mandatory": true,
              "validation": "{\"mandatory\":{\"errorMessage\":\"Select any previous convictions\",\"errorSummary\":\"Select any previous convictions\"}}",
              "readOnly": false,
              "conditional": false,
              "answerSchemas": []
            },
            { ... more questions ... }
          ],
        }
        { ... more ROSH groups },
    }
    { ... more sections ... }
}
```

Where we have something like children, where we can have 0-to-N answers, instead of an element with `type='question'` we'll have an element with `type='table'`. A table will have the same shape as a group - ie with the title text, containing the various questions that make up the table, and so on. That fact that it's a table is the hint to the front end to leap into life and do whatever our UX colleagues come up with for tables.  
```
        {
          "type": "group",
          "groupId": "946091d2-4038-4e2b-9283-83cc4876f6ed",
          "groupCode": "risk_to_others",
          "title": "Risk to others",
          "displayOrder": 1,
          "mandatory": true,
          "contents": [
            { ... question ... }
            {
              "type": "table",
              "tableId": "946091d2-4038-4e2b-9283-83cc4876f6ed",
              "tableCode": "children",
              "title": "Children",
              "displayOrder": 2,
              "contents": [
                {
                  "type": "question",
                  "questionId": "... uuid ...",
                  "questionCode": "129.1",
                  "answerType": "text",
                  "questionText": "Child's name",
                  ...
                },
                { ... question ... },
                { ... question ... }
              ],
            },
            { ... question ... }
            ...
          ],

```