### PR TITLE
Update reference data targets to use UUIDs

### DIFF
--- a/psr/index.js
+++ b/psr/index.js
@@ -23,5 +23,6 @@ for (const record of records) {
 }
 
 assessment.addDependencyUuids()
+assessment.addFilteredReferenceDataTargets()
 assessment.toSql()
 

--- a/psr/lib/assessment-sql.js
+++ b/psr/lib/assessment-sql.js
@@ -47,7 +47,9 @@ class AssessmentSql {
             return oasys_fixed_field === target_field
           })
 
-          if (matches.length > 1) {
+          if (matches.length < 1) {
+            console.warn(`No matching target found for question "${question.question_text}"`)
+          } else if (matches.length > 1) {
             console.warn(`Ambiguous match for question "${question.question_text}" - ${matches.length} results found for reference data target`)
           } else {
             const [[_, reference_field_uuid]] = matches

--- a/psr/lib/assessment-sql.js
+++ b/psr/lib/assessment-sql.js
@@ -20,9 +20,44 @@ class AssessmentSql {
     this.assessmentGroup = this._createGrouping([assessmentName])
     this.currentGroup = this.assessmentGroup
     this.dependencies = []
+    this.questionsWithReferenceDataTargets = []
+    this.fixedOasysCodeLookup = []
 
     this.oasysQuestions = oasysQuestions()
     this.yes_no = ['radio', this.answerSchemaGroup(['radios:', 'Yes|YES', 'No|NO'])]
+  }
+
+  addFilteredReferenceDataTargets() {
+    const hasReferenceDataTarget = ({question_schema_uuid}) => this.questionsWithReferenceDataTargets.filter(([uuid]) => uuid === question_schema_uuid).length > 0
+    const withoutTargets = this.questions.filter(q => !hasReferenceDataTarget(q))
+    const withTargets = this.questions.filter(q => hasReferenceDataTarget(q))
+
+    console.warn(`Adding reference data targets for ${withTargets.length} item(s)`)
+
+    this.questions = [
+        ...withoutTargets,
+        ...withTargets.map(question => {
+          const result = {
+            ...question,
+          }
+
+          const [_, target_field] = this.questionsWithReferenceDataTargets.filter(([uuid]) => uuid === question.question_schema_uuid).shift()
+
+          const matches = this.fixedOasysCodeLookup.filter(([oasys_fixed_field]) => {
+            return oasys_fixed_field === target_field
+          })
+
+          if (matches.length > 1) {
+            console.warn(`Ambiguous match for question "${question.question_text}" - ${matches.length} results found for reference data target`)
+          } else {
+            const [[_, reference_field_uuid]] = matches
+            console.warn(`Found reference data target UUID for "${question.question_text}" - "${reference_field_uuid}"`)
+            result.reference_data_target = reference_field_uuid
+          }
+
+          return result
+        })
+    ]
   }
 
   addDependencyUuids() {
@@ -124,12 +159,20 @@ class AssessmentSql {
     const question_text = record[this.headers.QUESTION].replace(/'/g, "''").replace(/\r\n/g, ' ').trim()
     const question_help_text = record[this.headers.HINT_TEXT].replace(/'/g, "''").replace(/\r\n/g, ' ').replace(/\[.*\] *\n*/g, '')
     const [answer_type, answer_schema_group_uuid, read_only] = this.answerType(record[this.headers.ANSWER_TYPE], oasys_question)
+    const question_schema_uuid = questionUuids(question_code, answer_type, question_title)
 
     const business_logic = record[this.headers.LOGIC]
     const reference_data_category = record[this.headers.REFERENCE_DATA_CATEGORY]
     const reference_data_target = record[this.headers.REFERENCE_DATA_TARGET]
+
+    if (reference_data_target)
+      this.questionsWithReferenceDataTargets.push([question_schema_uuid, reference_data_target])
+
+    if (oasys_fixed_field)
+      this.fixedOasysCodeLookup.push([oasys_fixed_field, question_schema_uuid])
+
     const question = {
-      question_schema_uuid: questionUuids(question_code, answer_type, question_title),
+      question_schema_uuid:  question_schema_uuid,
       question_code: question_code,
       oasys_question_code: oasys_question_code,
       answer_type: answer_type,
@@ -140,7 +183,6 @@ class AssessmentSql {
       external_source: externalSources(question_code),
       read_only: (question_code.substring(0,2) === 'ui' ? true : read_only),
       reference_data_category: reference_data_category,
-      reference_data_target: reference_data_target,
     }
     this.questions.push(question)
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupQuestionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/GroupQuestionDto.kt
@@ -41,7 +41,7 @@ data class GroupQuestionDto(
   val referenceDataCategory: String? = null,
 
   @Schema(description = "Reference Data Target", example = "assessor,assessor_office,assessor_team")
-  val referenceDataTarget: String? = null,
+  val referenceDataTarget: UUID? = null,
 
   @Schema(description = "Reference Answer Schemas")
   val answerSchemas: Collection<AnswerSchemaDto>? = null,
@@ -64,7 +64,7 @@ data class GroupQuestionDto(
         readOnly = questionGroupEntity.readOnly,
         conditional = questionDependencies.hasDependency(questionSchemaEntity.questionSchemaUuid),
         referenceDataCategory = questionSchemaEntity.referenceDataCategory,
-        referenceDataTarget = questionSchemaEntity.referenceDataTarget,
+        referenceDataTarget = questionSchemaEntity.referenceDataTarget?.questionSchemaUuid,
         answerSchemas = AnswerSchemaDto.from(
           questionSchemaEntity.answerSchemaEntities,
           questionDependencies.answerTriggers(questionSchemaEntity.questionSchemaUuid)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/QuestionSchemaDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/QuestionSchemaDto.kt
@@ -38,7 +38,7 @@ data class QuestionSchemaDto(
   val referenceDataCategory: String? = null,
 
   @Schema(description = "Reference Data Category")
-  val referenceDataTarget: String? = null,
+  val referenceDataTarget: UUID? = null,
 
   @Schema(description = "List of Reference Answer Schemas")
   val answerSchemas: Collection<AnswerSchemaDto>,
@@ -63,7 +63,7 @@ data class QuestionSchemaDto(
         questionSchema?.questionText,
         questionSchema?.questionHelpText,
         questionSchema?.referenceDataCategory,
-        questionSchema?.referenceDataTarget,
+        questionSchema?.referenceDataTarget?.questionSchemaUuid,
         AnswerSchemaDto.from(
           questionSchema?.answerSchemaEntities
         )

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/QuestionSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/QuestionSchemaEntity.kt
@@ -53,8 +53,9 @@ class QuestionSchemaEntity(
   @Column(name = "reference_data_category")
   val referenceDataCategory: String? = null,
 
-  @Column(name = "reference_data_target")
-  val referenceDataTarget: String? = null,
+  @ManyToOne()
+  @JoinColumn(name = "reference_data_target", referencedColumnName = "question_schema_uuid")
+  val referenceDataTarget: QuestionSchemaEntity? = null,
 
   @ManyToOne
   @JoinColumn(name = "answer_schema_group_uuid", referencedColumnName = "answer_schema_group_uuid")

--- a/src/main/resources/db/migration/V1_0__reference_data.sql
+++ b/src/main/resources/db/migration/V1_0__reference_data.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS question_schema
     question_text           TEXT,
     question_help_text      TEXT,
     reference_data_category TEXT,
-    reference_data_target TEXT,
+    reference_data_target   UUID,
     FOREIGN KEY (answer_schema_group_uuid) REFERENCES answer_schema_group (answer_schema_group_uuid)
 );
 
@@ -49,6 +49,9 @@ CREATE TABLE IF NOT EXISTS oasys_question_mapping
     fixed_field           BOOLEAN,
     FOREIGN KEY (question_schema_uuid) REFERENCES question_schema (question_schema_uuid)
 );
+
+ALTER TABLE question_schema
+    ADD FOREIGN KEY (reference_data_target) REFERENCES question_schema (question_schema_uuid);
 
 CREATE TABLE IF NOT EXISTS grouping
 (

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/QuestionSchemaDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/QuestionSchemaDtoTest.kt
@@ -11,6 +11,11 @@ class QuestionSchemaDtoTest {
   @Test
   fun `builds valid Question Schema DTO`() {
 
+    val targetQuestionSchemaEntity = QuestionSchemaEntity(
+      questionSchemaId = 2L,
+      questionSchemaUuid = UUID.randomUUID(),
+    )
+
     val questionSchemaEntity = QuestionSchemaEntity(
       1L,
       UUID.randomUUID(),
@@ -23,7 +28,7 @@ class QuestionSchemaDtoTest {
       "Question text",
       "Question help text",
       "TEST_REF_DATA_CAT",
-      "test_field_1,test_field_2,test_field_3",
+      targetQuestionSchemaEntity,
     )
 
     val questionSchemaDto = QuestionSchemaDto.from(questionSchemaEntity)
@@ -38,6 +43,6 @@ class QuestionSchemaDtoTest {
     assertThat(questionSchemaDto.questionText).isEqualTo(questionSchemaEntity.questionText)
     assertThat(questionSchemaDto.questionHelpText).isEqualTo(questionSchemaEntity.questionHelpText)
     assertThat(questionSchemaDto.referenceDataCategory).isEqualTo(questionSchemaEntity.referenceDataCategory)
-    assertThat(questionSchemaDto.referenceDataTarget).isEqualTo(questionSchemaEntity.referenceDataTarget)
+    assertThat(questionSchemaDto.referenceDataTarget).isEqualTo(questionSchemaEntity.referenceDataTarget?.questionSchemaUuid)
   }
 }


### PR DESCRIPTION
### Context

This PR aims to allow use to use OASys fixed field codes when specifying reference data targets in the question CSV, the tool matches these and allows the service to persist and serve the Question Schema UUIDs for the target fields.

### Intent

- Update PSR CSV import tooling to lookup Question Schema UUIDs from OASys Fixed Fields
- Update base migration for Question Schema
- Update Question Schema response DTOs
- Update Question Schema entity