### PR TITLE
Arn 395 update children in oasys

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -253,7 +253,9 @@ class AssessmentService(
     }
 
     val questions = questionService.getAllQuestions()
-    val oasysAnswers = OasysAnswers.from(episode, questions)
+    val oasysAnswers = OasysAnswers.from(episode, object: OasysAnswers.Companion.MappingProvider {
+      override fun getAllQuestions(): QuestionSchemaEntities = questionService.getAllQuestions()
+    })
 
     val oasysUpdateResult = assessmentUpdateRestClient.updateAssessment(offenderPk, episode.oasysSetPk!!, episode.assessmentType!!, oasysAnswers)
     log.info("Updated OASys assessment oasysSet ${episode.oasysSetPk} ${if (oasysUpdateResult?.validationErrorDtos?.isNotEmpty() == true) "with errors" else "successfully"}")

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -255,6 +255,8 @@ class AssessmentService(
     val questions = questionService.getAllQuestions()
     val oasysAnswers = OasysAnswers.from(episode, object: OasysAnswers.Companion.MappingProvider {
       override fun getAllQuestions(): QuestionSchemaEntities = questionService.getAllQuestions()
+      override fun getTableQuestions(tableCode: String): QuestionSchemaEntities =
+        questionService.getAllGroupQuestions(tableCode)
     })
 
     val oasysUpdateResult = assessmentUpdateRestClient.updateAssessment(offenderPk, episode.oasysSetPk!!, episode.assessmentType!!, oasysAnswers)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
@@ -135,6 +135,12 @@ class QuestionService(
     return QuestionSchemaEntities(questionSchemaRepository.findAll())
   }
 
+  fun getAllGroupQuestions(groupCode: String): QuestionSchemaEntities {
+    val group = findByGroupCode(groupCode)
+    val questionsInGroup = group.contents.filter { it.question != null }.map { it.question!! }
+    return QuestionSchemaEntities(questionsInGroup)
+  }
+
   fun getAllAnswers(): List<AnswerSchemaEntity> {
     return answerSchemaRepository.findAll()
   }
@@ -160,7 +166,7 @@ class QuestionService(
 
 class QuestionSchemaEntities(
   questionsList: List<QuestionSchemaEntity>
-) {
+): List<QuestionSchemaEntity> by questionsList {
   private val questions = questionsList.map { it.questionSchemaUuid to it }.toMap()
   private val oasysMapping = mapByOasysCoords(questionsList)
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
@@ -27,8 +27,7 @@ class OasysAnswers(
       episode: AssessmentEpisodeEntity,
       mappingProvider: MappingProvider
     ): OasysAnswers {
-      val oasysAnswers = OasysAnswers()
-      val episodeAnswers = episode.answers ?: return oasysAnswers
+      val episodeAnswers = episode.answers ?: return OasysAnswers()
 
       val questions = mappingProvider.getAllQuestions()
       val tables = pullTableNames(questions)
@@ -36,57 +35,17 @@ class OasysAnswers(
       val (processedQuestions, oasysTableAnswers) =
         buildAllTableAnswers(tables, episodeAnswers, mappingProvider)
 
+      val nonTableAnswers = buildOasysAnswers(
+        questions,
+        episodeAnswers.filterNot { episodeAnswer -> // skip table questions - we've already done them
+          processedQuestions.contains(episodeAnswer.key) },
+        ::mapOasysAnswers)
+
+      val oasysAnswers = OasysAnswers()
       oasysAnswers.addAll(oasysTableAnswers)
-
-      // TODO: If we want to handle multiple mappings per question we will need to add assessment type to the mapping
-      episodeAnswers
-        .filterNot { episodeAnswer ->
-          processedQuestions.contains(episodeAnswer.key) } // skip table questions - we've already done them
-        .forEach { episodeAnswer ->
-          val question = questions[episodeAnswer.key]
-          val oasysMapping = question?.oasysMappings?.toList()?.getOrNull(0)
-          oasysAnswers.addAll(
-            mapOasysAnswer(
-              oasysMapping,
-              episodeAnswer.value.answers,
-              question?.answerType
-            )
-          )
-        }
-
+      oasysAnswers.addAll(nonTableAnswers)
       return oasysAnswers
     }
-
-    fun mapOasysAnswer(
-      oasysMapping: OASysMappingEntity?,
-      answers: Collection<String>,
-      answerType: String?
-    ): List<OasysAnswer> {
-      if (oasysMapping == null) return emptyList()
-
-      return answers.map { it ->
-        val answer = when (answerType) {
-          "date" -> toOASysDate(it)
-          else -> it
-        }
-
-        OasysAnswer(
-          oasysMapping.sectionCode,
-          oasysMapping.logicalPage,
-          oasysMapping.questionCode,
-          answer,
-          oasysMapping.isFixed
-        )
-      }.toList()
-    }
-
-    private fun toOASysDate(dateStr: String): String {
-      if (dateStr.length < 10)
-        return dateStr
-      return LocalDate.parse(dateStr.substring(0, 10), DateTimeFormatter.ISO_DATE).format(oasysDateFormatter)
-    }
-
-    val oasysDateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
     private fun pullTableNames(questions: QuestionSchemaEntities): Set<String> {
       return questions
@@ -100,28 +59,28 @@ class OasysAnswers(
       answers: Map<UUID, AnswerEntity>,
       mappingProvider: MappingProvider): Pair<Set<UUID>, OasysAnswers> {
 
-      val tableQuestionIds = mutableSetOf<UUID>()
-      val mappingAnswers = OasysAnswers()
+      val allTableQuestionIds = mutableSetOf<UUID>()
+      val allTableAnswers = OasysAnswers()
       tables.forEach { table ->
         val tableQuestions = mappingProvider.getTableQuestions(table)
 
-        tableQuestionIds.addAll(tableQuestions.map { it.questionSchemaUuid })
-        mappingAnswers.addAll(buildTableAnswers(tableQuestions, answers))
+        val (tableQuestionIds, tableAnswers) = buildTableAnswers(tableQuestions, answers)
+
+        allTableQuestionIds.addAll(tableQuestionIds)
+        allTableAnswers.addAll(tableAnswers)
       }
-      return Pair(tableQuestionIds, mappingAnswers)
+      return Pair(allTableQuestionIds, allTableAnswers)
     }
 
     private fun buildTableAnswers(
       tableQuestions: QuestionSchemaEntities,
       answers: Map<UUID, AnswerEntity>
-    ): OasysAnswers {
-      val oasysAnswers = OasysAnswers()
-
+    ): Pair<List<UUID>, OasysAnswers> {
       // gather tables answers
       val questionUuids = tableQuestions.map { it.questionSchemaUuid }
       val tableAnswers = answers.filter { questionUuids.contains(it.key) }
 
-      if (tableAnswers.isEmpty()) return oasysAnswers
+      if (tableAnswers.isEmpty()) return Pair(questionUuids, OasysAnswers())
 
       // consistency check
       val tableLength = tableAnswers.values.first().answers.size
@@ -129,43 +88,75 @@ class OasysAnswers(
         throw IllegalStateException("Inconsistent table answers") // this is rubbish message
 
       // build OasysAnswers
-      tableAnswers.forEach { tableAnswer ->
-        val question = tableQuestions[tableAnswer.key]
-        val oasysMapping = question?.oasysMappings?.toList()?.getOrNull(0)
-        oasysAnswers.addAll(
-          mapOasysTableAnswer(
-            oasysMapping,
-            tableAnswer.value.answers,
-            question?.answerType
-          )
-        )
-      }
+      return Pair(
+        questionUuids,
+        buildOasysAnswers(tableQuestions, tableAnswers, ::mapOasysTableAnswers)
+      )
+    }
 
+    private fun buildOasysAnswers(
+      questions: QuestionSchemaEntities,
+      answers: Map<UUID, AnswerEntity>,
+      builder: (OASysMappingEntity, Collection<String>, String?) -> List<OasysAnswer>
+    ): OasysAnswers {
+      val oasysAnswers = OasysAnswers()
+      answers.forEach { tableAnswer ->
+        val question = questions[tableAnswer.key]
+        // TODO: If we want to handle multiple mappings per question we will need to add assessment type to the mapping
+        question?.oasysMappings?.firstOrNull()?.let { oasysMapping ->
+          oasysAnswers.addAll(
+            builder(oasysMapping, tableAnswer.value.answers, question?.answerType)
+          )
+        }
+      }
       return oasysAnswers
     }
 
-    fun mapOasysTableAnswer(
-      oasysMapping: OASysMappingEntity?,
+    fun mapOasysAnswers(
+      oasysMapping: OASysMappingEntity,
       answers: Collection<String>,
       answerType: String?
     ): List<OasysAnswer> {
-      if (oasysMapping == null) return emptyList()
-
-      return answers.mapIndexed { index, value ->
-        val answer = when (answerType) {
-          "date" -> toOASysDate(value)
-          else -> value
-        }
-
-        OasysAnswer(
-          oasysMapping.sectionCode,
-          index.toLong(),
-          oasysMapping.questionCode,
-          answer,
-          oasysMapping.isFixed
-        )
+      return answers.map {
+        makeOasysAnswer(it, oasysMapping, answerType)
       }.toList()
     }
 
+    private fun mapOasysTableAnswers(
+      oasysMapping: OASysMappingEntity,
+      answers: Collection<String>,
+      answerType: String?
+    ): List<OasysAnswer> {
+      return answers.mapIndexed { index, value ->
+        makeOasysAnswer(value, oasysMapping, answerType, index.toLong())
+      }.toList()
+    }
+
+    private fun makeOasysAnswer(
+      value: String,
+      oasysMapping: OASysMappingEntity,
+      answerType: String?,
+      index: Long? = null): OasysAnswer {
+      val answer = when (answerType) {
+        "date" -> toOASysDate(value)
+        else -> value
+      }
+
+      return OasysAnswer(
+        oasysMapping.sectionCode,
+        index ?: oasysMapping.logicalPage,
+        oasysMapping.questionCode,
+        answer,
+        oasysMapping.isFixed
+      )
+    }
+
+    private fun toOASysDate(dateStr: String): String {
+      if (dateStr.length < 10)
+        return dateStr
+      return LocalDate.parse(dateStr.substring(0, 10), DateTimeFormatter.ISO_DATE).format(oasysDateFormatter)
+    }
+
+    val oasysDateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.assessments.services.dto
 
+import uk.gov.justice.digital.assessments.jpa.entities.AnswerEntity
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
 import uk.gov.justice.digital.assessments.jpa.entities.OASysMappingEntity
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
 import uk.gov.justice.digital.assessments.services.QuestionSchemaEntities
+import java.lang.IllegalStateException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.*
 
 class OasysAnswers(
   private val allAnswers: MutableSet<OasysAnswer> = mutableSetOf()
@@ -17,6 +20,7 @@ class OasysAnswers(
   companion object {
     interface MappingProvider {
       fun getAllQuestions(): QuestionSchemaEntities
+      fun getTableQuestions(tableCode: String): QuestionSchemaEntities
     }
 
     fun from(
@@ -24,20 +28,31 @@ class OasysAnswers(
       mappingProvider: MappingProvider
     ): OasysAnswers {
       val oasysAnswers = OasysAnswers()
+      val episodeAnswers = episode.answers ?: return oasysAnswers
 
       val questions = mappingProvider.getAllQuestions()
+      val tables = pullTableNames(questions)
+
+      val (processedQuestions, oasysTableAnswers) =
+        buildAllTableAnswers(tables, episodeAnswers, mappingProvider)
+
+      oasysAnswers.addAll(oasysTableAnswers)
+
       // TODO: If we want to handle multiple mappings per question we will need to add assessment type to the mapping
-      episode.answers?.forEach { episodeAnswer ->
-        val question = questions[episodeAnswer.key]
-        val oasysMapping = question?.oasysMappings?.toList()?.getOrNull(0)
-        oasysAnswers.addAll(
-          mapOasysAnswer(
-            oasysMapping,
-            episodeAnswer.value.answers,
-            question?.answerType
+      episodeAnswers
+        .filterNot { episodeAnswer ->
+          processedQuestions.contains(episodeAnswer.key) } // skip table questions - we've already done them
+        .forEach { episodeAnswer ->
+          val question = questions[episodeAnswer.key]
+          val oasysMapping = question?.oasysMappings?.toList()?.getOrNull(0)
+          oasysAnswers.addAll(
+            mapOasysAnswer(
+              oasysMapping,
+              episodeAnswer.value.answers,
+              question?.answerType
+            )
           )
-        )
-      }
+        }
 
       return oasysAnswers
     }
@@ -72,5 +87,85 @@ class OasysAnswers(
     }
 
     val oasysDateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+    private fun pullTableNames(questions: QuestionSchemaEntities): Set<String> {
+      return questions
+        .filter { it.answerType?.startsWith("table:") == true }
+        .map { it.answerType!!.split(":")[1] }
+        .toSet()
+    }
+
+    private fun buildAllTableAnswers(
+      tables: Set<String>,
+      answers: Map<UUID, AnswerEntity>,
+      mappingProvider: MappingProvider): Pair<Set<UUID>, OasysAnswers> {
+
+      val tableQuestionIds = mutableSetOf<UUID>()
+      val mappingAnswers = OasysAnswers()
+      tables.forEach { table ->
+        val tableQuestions = mappingProvider.getTableQuestions(table)
+
+        tableQuestionIds.addAll(tableQuestions.map { it.questionSchemaUuid })
+        mappingAnswers.addAll(buildTableAnswers(tableQuestions, answers))
+      }
+      return Pair(tableQuestionIds, mappingAnswers)
+    }
+
+    private fun buildTableAnswers(
+      tableQuestions: QuestionSchemaEntities,
+      answers: Map<UUID, AnswerEntity>
+    ): OasysAnswers {
+      val oasysAnswers = OasysAnswers()
+
+      // gather tables answers
+      val questionUuids = tableQuestions.map { it.questionSchemaUuid }
+      val tableAnswers = answers.filter { questionUuids.contains(it.key) }
+
+      if (tableAnswers.isEmpty()) return oasysAnswers
+
+      // consistency check
+      val tableLength = tableAnswers.values.first().answers.size
+      if (tableAnswers.values.filter { it.answers.size != tableLength }.isNotEmpty())
+        throw IllegalStateException("Inconsistent table answers") // this is rubbish message
+
+      // build OasysAnswers
+      tableAnswers.forEach { tableAnswer ->
+        val question = tableQuestions[tableAnswer.key]
+        val oasysMapping = question?.oasysMappings?.toList()?.getOrNull(0)
+        oasysAnswers.addAll(
+          mapOasysTableAnswer(
+            oasysMapping,
+            tableAnswer.value.answers,
+            question?.answerType
+          )
+        )
+      }
+
+      return oasysAnswers
+    }
+
+    fun mapOasysTableAnswer(
+      oasysMapping: OASysMappingEntity?,
+      answers: Collection<String>,
+      answerType: String?
+    ): List<OasysAnswer> {
+      if (oasysMapping == null) return emptyList()
+
+      return answers.mapIndexed { index, value ->
+        val answer = when (answerType) {
+          "date" -> toOASysDate(value)
+          else -> value
+        }
+
+        OasysAnswer(
+          oasysMapping.sectionCode,
+          index.toLong(),
+          oasysMapping.questionCode,
+          answer,
+          oasysMapping.isFixed
+        )
+      }.toList()
+    }
+
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
@@ -15,12 +15,17 @@ class OasysAnswers(
   }
 
   companion object {
+    interface MappingProvider {
+      fun getAllQuestions(): QuestionSchemaEntities
+    }
+
     fun from(
       episode: AssessmentEpisodeEntity,
-      questions: QuestionSchemaEntities
+      mappingProvider: MappingProvider
     ): OasysAnswers {
       val oasysAnswers = OasysAnswers()
 
+      val questions = mappingProvider.getAllQuestions()
       // TODO: If we want to handle multiple mappings per question we will need to add assessment type to the mapping
       episode.answers?.forEach { episodeAnswer ->
         val question = questions[episodeAnswer.key]

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCompleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCompleteTest.kt
@@ -26,7 +26,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
-@DisplayName("Assessment Service Tests")
+@DisplayName("Assessment Service Complete Tests")
 class AssessmentServiceCompleteTest {
   private val assessmentRepository: AssessmentRepository = mockk()
   private val episodeRepository: EpisodeRepository = mockk()
@@ -48,33 +48,29 @@ class AssessmentServiceCompleteTest {
     offenderService
   )
 
-  @Nested
-  @DisplayName("completing assessments")
-  inner class CompletingAssessments {
-    @Test
-    fun `close episode`() {
-      val assessment = assessmentEntity()
-      every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
-      every { episodeRepository.save(any()) } returns assessment.episodes[0]
-      every {
-        assessmentUpdateRestClient.completeAssessment(9999, 7777, AssessmentType.SHORT_FORM_PSR)
-      } returns UpdateAssessmentAnswersResponseDto(7777)
+  @Test
+  fun `close episode`() {
+    val assessment = assessmentEntity()
+    every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
+    every { episodeRepository.save(any()) } returns assessment.episodes[0]
+    every {
+      assessmentUpdateRestClient.completeAssessment(9999, 7777, AssessmentType.SHORT_FORM_PSR)
+    } returns UpdateAssessmentAnswersResponseDto(7777)
 
-      val episode = assessmentsService.closeCurrentEpisode(UUID.fromString("7b4de6d5-4488-4c29-a909-7d3fdf15393d"))
+    val episode = assessmentsService.closeCurrentEpisode(UUID.fromString("7b4de6d5-4488-4c29-a909-7d3fdf15393d"))
 
-      verify(exactly = 1) { episodeRepository.save(any()) }
-      verify(exactly = 1) { assessmentUpdateRestClient.completeAssessment(any(), any(), any(), any()) }
-      assertThat(episode.ended).isEqualToIgnoringMinutes(LocalDateTime.now())
-    }
+    verify(exactly = 1) { episodeRepository.save(any()) }
+    verify(exactly = 1) { assessmentUpdateRestClient.completeAssessment(any(), any(), any(), any()) }
+    assertThat(episode.ended).isEqualToIgnoringMinutes(LocalDateTime.now())
+  }
 
-    @Test
-    fun `close episode for assessment with no episodes throws exception`() {
-      every { assessmentRepository.findByAssessmentUuid(any()) } returns assessmentWithNoEpisodeEntity()
+  @Test
+  fun `close episode for assessment with no episodes throws exception`() {
+    every { assessmentRepository.findByAssessmentUuid(any()) } returns assessmentWithNoEpisodeEntity()
 
-      assertThrows<EntityNotFoundException> { assessmentsService.closeCurrentEpisode(UUID.fromString("7b4de6d5-4488-4c29-a909-7d3fdf15393d")) }
-      verify(exactly = 0) { episodeRepository.save(any()) }
-      verify(exactly = 0) { assessmentUpdateRestClient.completeAssessment(any(), any(), any(), any()) }
-    }
+    assertThrows<EntityNotFoundException> { assessmentsService.closeCurrentEpisode(UUID.fromString("7b4de6d5-4488-4c29-a909-7d3fdf15393d")) }
+    verify(exactly = 0) { episodeRepository.save(any()) }
+    verify(exactly = 0) { assessmentUpdateRestClient.completeAssessment(any(), any(), any(), any()) }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCreateTest.kt
@@ -1,0 +1,213 @@
+package uk.gov.justice.digital.assessments.services
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.assessments.api.CreateAssessmentDto
+import uk.gov.justice.digital.assessments.api.OffenderDto
+import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
+import uk.gov.justice.digital.assessments.jpa.entities.AnswerEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaGroupEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
+import uk.gov.justice.digital.assessments.jpa.entities.OASysMappingEntity
+import uk.gov.justice.digital.assessments.jpa.entities.QuestionSchemaEntity
+import uk.gov.justice.digital.assessments.jpa.entities.SubjectEntity
+import uk.gov.justice.digital.assessments.jpa.repositories.AssessmentRepository
+import uk.gov.justice.digital.assessments.jpa.repositories.EpisodeRepository
+import uk.gov.justice.digital.assessments.jpa.repositories.SubjectRepository
+import uk.gov.justice.digital.assessments.restclient.AssessmentUpdateRestClient
+import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.ValidationErrorDto
+import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
+import uk.gov.justice.digital.assessments.services.dto.OasysAnswers
+import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.UpdateClosedEpisodeException
+import java.time.LocalDateTime
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+@DisplayName("Assessment Service Create Tests")
+class AssessmentServiceCreateTest {
+  private val assessmentRepository: AssessmentRepository = mockk()
+  private val episodeRepository: EpisodeRepository = mockk()
+  private val subjectRepository: SubjectRepository = mockk()
+  private val questionService: QuestionService = mockk()
+  private val courtCaseRestClient: CourtCaseRestClient = mockk()
+  private val episodeService: EpisodeService = mockk()
+  private val offenderService: OffenderService = mockk()
+  private val assessmentUpdateRestClient: AssessmentUpdateRestClient = mockk()
+
+  private val assessmentsService = AssessmentService(
+    assessmentRepository,
+    episodeRepository,
+    subjectRepository,
+    questionService,
+    episodeService,
+    courtCaseRestClient,
+    assessmentUpdateRestClient,
+    offenderService
+  )
+
+  private val assessmentUuid = UUID.randomUUID()
+  private val assessmentId = 1L
+  private val assessmentType = AssessmentType.SHORT_FORM_PSR
+
+  private val oasysOffenderPk = 1L
+  private val crn = "X12345"
+  private val oasysSetPk = 1L
+
+  private val courtCode = "SHF06"
+  private val caseNumber = "668911253"
+
+  private val deliusSource = "DELIUS"
+  private val eventId = 1L
+
+  @Nested
+  @DisplayName("creating assessments from Delius")
+  inner class CreatingDeliusAssessments {
+    @Test
+    fun `create new offender with new assessment from delius event id and crn`() {
+      every { subjectRepository.findBySourceAndSourceIdAndCrn(deliusSource, eventId.toString(), crn) } returns null
+      every { offenderService.getOffender("X12345") } returns OffenderDto()
+      every { assessmentUpdateRestClient.createOasysOffender(crn = crn, deliusEvent = eventId) } returns oasysOffenderPk
+      every { assessmentUpdateRestClient.createAssessment(oasysOffenderPk, assessmentType) } returns oasysSetPk
+      every { episodeService.prepopulate(any()) } returnsArgument 0
+      every { assessmentRepository.save(any()) } returns AssessmentEntity(assessmentId = assessmentId)
+
+      assessmentsService.createNewAssessment(
+        CreateAssessmentDto(
+          deliusEventId = eventId,
+          crn = crn,
+          assessmentType = assessmentType
+        )
+      )
+      verify(exactly = 1) { assessmentRepository.save(any()) }
+    }
+
+    @Test
+    fun `return existing assessment from delius event id and crn if one already exists`() {
+      every { subjectRepository.findBySourceAndSourceIdAndCrn(deliusSource, eventId.toString(), crn) } returns
+        SubjectEntity(assessment = AssessmentEntity(assessmentId = assessmentId, assessmentUuid = assessmentUuid))
+
+      val assessmentDto =
+        assessmentsService.createNewAssessment(
+          CreateAssessmentDto(
+            deliusEventId = eventId,
+            crn = crn,
+            assessmentType = assessmentType
+          )
+        )
+      assertThat(assessmentDto.assessmentUuid).isEqualTo(assessmentUuid)
+      verify(exactly = 0) { assessmentRepository.save(any()) }
+    }
+
+    @Test
+    fun `throw exception if crn is null`() {
+      assertThrows<IllegalStateException> {
+        assessmentsService.createNewAssessment(
+          CreateAssessmentDto(
+            deliusEventId = eventId,
+            crn = null,
+            assessmentType = assessmentType
+          )
+        )
+      }
+      verify(exactly = 0) { assessmentRepository.save(any()) }
+    }
+
+    @Test
+    fun `throw exception if delius event id is null`() {
+      assertThrows<IllegalStateException> {
+        assessmentsService.createNewAssessment(
+          CreateAssessmentDto(
+            deliusEventId = null,
+            crn = crn,
+            assessmentType = assessmentType
+          )
+        )
+      }
+      verify(exactly = 0) { assessmentRepository.save(any()) }
+    }
+
+    @Test
+    fun `throw exception if offender is not returned from Delius`() {
+      every { subjectRepository.findBySourceAndSourceIdAndCrn(deliusSource, eventId.toString(), crn) } returns null
+      every { offenderService.getOffender("X12345") } throws EntityNotFoundException("")
+
+      assertThrows<EntityNotFoundException> {
+        assessmentsService.createNewAssessment(
+          CreateAssessmentDto(
+            deliusEventId = eventId,
+            crn = crn,
+            assessmentType = assessmentType
+          )
+        )
+      }
+      verify(exactly = 0) { assessmentRepository.save(any()) }
+    }
+  }
+
+  @Nested
+  @DisplayName("creating assessments from court")
+  inner class CreatingCourtAssessments {
+    @Test
+    fun `create new assessment from court`() {
+      every {
+        subjectRepository.findBySourceAndSourceId(
+          AssessmentService.courtSource,
+          "$courtCode|$caseNumber"
+        )
+      } returns null
+      every { assessmentRepository.save(any()) } returns AssessmentEntity(assessmentId = assessmentId)
+      every { courtCaseRestClient.getCourtCase(courtCode, caseNumber) } returns CourtCase(crn = crn)
+      every { assessmentUpdateRestClient.createOasysOffender(crn) } returns oasysOffenderPk
+      every { assessmentUpdateRestClient.createAssessment(oasysOffenderPk, assessmentType) } returns oasysSetPk
+      every { episodeService.prepopulate(any()) } returnsArgument 0
+
+      assessmentsService.createNewAssessment(
+        CreateAssessmentDto(
+          courtCode = courtCode,
+          caseNumber = caseNumber,
+          assessmentType = assessmentType
+        )
+      )
+
+      verify(exactly = 1) { assessmentRepository.save(any()) }
+      verify(exactly = 1) { courtCaseRestClient.getCourtCase(courtCode, caseNumber) }
+    }
+
+    @Test
+    fun `return existing assessment if one exists from court`() {
+      every {
+        subjectRepository.findBySourceAndSourceId(
+          AssessmentService.courtSource,
+          "$courtCode|$caseNumber"
+        )
+      } returns SubjectEntity(assessment = AssessmentEntity(assessmentId = 1))
+
+      assessmentsService.createNewAssessment(
+        CreateAssessmentDto(
+          courtCode = courtCode,
+          caseNumber = caseNumber,
+          assessmentType = AssessmentType.SHORT_FORM_PSR
+        )
+      )
+
+      verify(exactly = 0) { assessmentRepository.save(any()) }
+      verify(exactly = 0) { courtCaseRestClient.getCourtCase(courtCode, caseNumber) }
+      verify(exactly = 0) { assessmentRepository.save(any()) }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
@@ -5,14 +5,10 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import uk.gov.justice.digital.assessments.api.CreateAssessmentDto
-import uk.gov.justice.digital.assessments.api.OffenderDto
 import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerEntity
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaEntity
@@ -31,11 +27,7 @@ import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.ValidationErrorDto
-import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
 import uk.gov.justice.digital.assessments.services.dto.OasysAnswers
-import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.UpdateClosedEpisodeException
-import java.time.LocalDateTime
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -86,7 +78,7 @@ class AssessmentServiceOASysTest {
   fun `map Oasys answer from free text answer`() {
     val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
 
-    val result = OasysAnswers.mapOasysAnswer(mapping, listOf("Free Text"), "radios")[0]
+    val result = OasysAnswers.mapOasysAnswers(mapping, listOf("Free Text"), "radios")[0]
 
     assertThat(result.answer).isEqualTo("Free Text")
     assertThat(result.logicalPage).isEqualTo(1)
@@ -99,7 +91,7 @@ class AssessmentServiceOASysTest {
   fun `map Oasys answer with correct date format`() {
     val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
 
-    val result = OasysAnswers.mapOasysAnswer(mapping, listOf("1975-01-20T00:00:00.000Z"), "date")[0]
+    val result = OasysAnswers.mapOasysAnswers(mapping, listOf("1975-01-20T00:00:00.000Z"), "date")[0]
 
     assertThat(result.answer).isEqualTo("20/01/1975")
     assertThat(result.logicalPage).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
@@ -124,7 +124,9 @@ class AssessmentServiceOASysTest {
       makeQuestion(3, question3Uuid, "ExtraInfo")
     ))
 
-    val oasysAnswers = OasysAnswers.from(episode, questions)
+    val oasysAnswers = OasysAnswers.from(episode, object: OasysAnswers.Companion.MappingProvider  {
+      override fun getAllQuestions(): QuestionSchemaEntities = questions
+    })
 
     assertThat(oasysAnswers).hasSize(2)
     assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "name", "some free text"))
@@ -156,7 +158,9 @@ class AssessmentServiceOASysTest {
       makeQuestion(11, childQuestion2, "Address", "freetext", null, "children", null, "childaddress")
     ))
 
-    val oasysAnswers = OasysAnswers.from(episode, questions)
+    val oasysAnswers = OasysAnswers.from(episode, object: OasysAnswers.Companion.MappingProvider  {
+      override fun getAllQuestions(): QuestionSchemaEntities = questions
+    })
 
     assertThat(oasysAnswers).hasSize(4)
     assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "name", "some free text"))

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
@@ -108,6 +108,27 @@ class AssessmentServiceOASysTest {
   }
 
   @Test
+  fun `map Oasys answers from ARN questions and answers`() {
+    val answers = mutableMapOf(
+      question1Uuid to AnswerEntity("some free text"),
+      question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
+      question3Uuid to AnswerEntity("not mapped to oasys")
+    )
+    val episode = AssessmentEpisodeEntity(
+      answers = answers
+    )
+    val questions = QuestionSchemaEntities(listOf(
+      makeQuestion(1, question1Uuid, "FreeText", "freetext", null, "section1", 1, "name"),
+      makeQuestion(2, question2Uuid, "Date", "date", null, "section1", 1, "dob"),
+      makeQuestion(3, question3Uuid, "ExtraInfo")
+    ))
+
+    val oasysAnswers = OasysAnswers.from(episode, questions);
+
+    assertThat(oasysAnswers).hasSize(2);
+  }
+
+  @Test
   fun `update OASys if OASysSet stored against episode`() {
     every { questionService.getAllQuestions() } returns setupQuestionCodes()
     every { assessmentUpdateRestClient.updateAssessment(oasysOffenderPk, oasysSetPk, assessmentType, any()) } returns UpdateAssessmentAnswersResponseDto()

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
@@ -136,22 +136,13 @@ class AssessmentServiceOASysTest {
     assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "dob", "20/01/1975"))
   }
 
-  @Test
-  fun `map Oasys answers from ARN questions and answers with one child`() {
+  @Nested
+  @DisplayName("map Oasys answers from ARN questions and answers with children")
+  inner class WithChildren {
     val tableQuestion = UUID.randomUUID()
     val childQuestion1 = UUID.randomUUID()
     val childQuestion2 = UUID.randomUUID()
-    val answers = mutableMapOf(
-      question1Uuid to AnswerEntity("some free text"),
-      question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
-      question3Uuid to AnswerEntity("not mapped to oasys"),
-      childQuestion1 to AnswerEntity("child name"),
-      childQuestion2 to AnswerEntity("child address")
-    )
 
-    val episode = AssessmentEpisodeEntity(
-      answers = answers
-    )
     val childNameQuestion = makeQuestion(10, childQuestion1, "Name", "freetext", null, "children", null, "childname")
     val childAddressQuestion = makeQuestion(11, childQuestion2, "Address", "freetext", null, "children", null, "childaddress")
 
@@ -168,72 +159,63 @@ class AssessmentServiceOASysTest {
       childAddressQuestion
     ))
 
-    val oasysAnswers = OasysAnswers.from(episode, object: OasysAnswers.Companion.MappingProvider  {
+    val testMapper =  object : OasysAnswers.Companion.MappingProvider {
       override fun getAllQuestions(): QuestionSchemaEntities = allQuestions
       override fun getTableQuestions(tableCode: String): QuestionSchemaEntities =
-        if(tableCode == "children_at_risk")
+        if (tableCode == "children_at_risk")
           childTableQuestions
         else
           throw RuntimeException("Should only be called for children_at_risk table")
-    })
+    }
 
-    assertThat(oasysAnswers).hasSize(4)
-    assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "name", "some free text"))
-    assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "dob", "20/01/1975"))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childname", "child name"))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childaddress", "child address"))
-  }
+    @Test
+    fun `with one child`() {
+      val answers = mutableMapOf(
+        question1Uuid to AnswerEntity("some free text"),
+        question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
+        question3Uuid to AnswerEntity("not mapped to oasys"),
+        childQuestion1 to AnswerEntity("child name"),
+        childQuestion2 to AnswerEntity("child address")
+      )
 
-  @Test
-  fun `map Oasys answers from ARN questions and answers with multiple children`() {
-    val tableQuestion = UUID.randomUUID()
-    val childQuestion1 = UUID.randomUUID()
-    val childQuestion2 = UUID.randomUUID()
-    val answers = mutableMapOf(
-      question1Uuid to AnswerEntity("some free text"),
-      question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
-      question3Uuid to AnswerEntity("not mapped to oasys"),
-      childQuestion1 to AnswerEntity(listOf("name1", "name2", "name3")),
-      childQuestion2 to AnswerEntity(listOf("address1", "", "address3"))
-    )
+      val episode = AssessmentEpisodeEntity(
+        answers = answers
+      )
+      val oasysAnswers = OasysAnswers.from(episode, testMapper)
 
-    val episode = AssessmentEpisodeEntity(
-      answers = answers
-    )
-    val childNameQuestion = makeQuestion(10, childQuestion1, "Name", "freetext", null, "children", null, "childname")
-    val childAddressQuestion = makeQuestion(11, childQuestion2, "Address", "freetext", null, "children", null, "childaddress")
+      assertThat(oasysAnswers).hasSize(4)
+      assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "name", "some free text"))
+      assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "dob", "20/01/1975"))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childname", "child name"))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childaddress", "child address"))
+    }
 
-    val allQuestions = QuestionSchemaEntities(listOf(
-      makeQuestion(1, question1Uuid, "FreeText", "freetext", null, "section1", 1, "name"),
-      makeQuestion(2, question2Uuid, "Date", "date", null, "section1", 1, "dob"),
-      makeQuestion(3, question3Uuid, "ExtraInfo"),
-      makeQuestion(4, tableQuestion, "Children", "table:children_at_risk"),
-      childNameQuestion,
-      childAddressQuestion
-    ))
-    val childTableQuestions = QuestionSchemaEntities(listOf(
-      childNameQuestion,
-      childAddressQuestion
-    ))
+    @Test
+    fun `with multiple children`() {
+      val answers = mutableMapOf(
+        question1Uuid to AnswerEntity("some free text"),
+        question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
+        question3Uuid to AnswerEntity("not mapped to oasys"),
+        childQuestion1 to AnswerEntity(listOf("name1", "name2", "name3")),
+        childQuestion2 to AnswerEntity(listOf("address1", "", "address3"))
+      )
 
-    val oasysAnswers = OasysAnswers.from(episode, object: OasysAnswers.Companion.MappingProvider  {
-      override fun getAllQuestions(): QuestionSchemaEntities = allQuestions
-      override fun getTableQuestions(tableCode: String): QuestionSchemaEntities =
-        if(tableCode == "children_at_risk")
-          childTableQuestions
-        else
-          throw RuntimeException("Should only be called for children_at_risk table")
-    })
+      val episode = AssessmentEpisodeEntity(
+        answers = answers
+      )
 
-    assertThat(oasysAnswers).hasSize(8)
-    assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "name", "some free text"))
-    assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "dob", "20/01/1975"))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childname", "name1"))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childaddress", "address1"))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 1, "childname", "name2"))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 1, "childaddress", ""))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 2, "childname", "name3"))
-    assertThat(oasysAnswers).contains(OasysAnswer("children", 2, "childaddress", "address3"))
+      val oasysAnswers = OasysAnswers.from(episode, testMapper)
+
+      assertThat(oasysAnswers).hasSize(8)
+      assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "name", "some free text"))
+      assertThat(oasysAnswers).contains(OasysAnswer("section1", 1, "dob", "20/01/1975"))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childname", "name1"))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 0, "childaddress", "address1"))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 1, "childname", "name2"))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 1, "childaddress", ""))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 2, "childname", "name3"))
+      assertThat(oasysAnswers).contains(OasysAnswer("children", 2, "childaddress", "address3"))
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceOASysTest.kt
@@ -1,0 +1,230 @@
+package uk.gov.justice.digital.assessments.services
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.assessments.api.CreateAssessmentDto
+import uk.gov.justice.digital.assessments.api.OffenderDto
+import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
+import uk.gov.justice.digital.assessments.jpa.entities.AnswerEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaGroupEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
+import uk.gov.justice.digital.assessments.jpa.entities.OASysMappingEntity
+import uk.gov.justice.digital.assessments.jpa.entities.QuestionSchemaEntity
+import uk.gov.justice.digital.assessments.jpa.entities.SubjectEntity
+import uk.gov.justice.digital.assessments.jpa.repositories.AssessmentRepository
+import uk.gov.justice.digital.assessments.jpa.repositories.EpisodeRepository
+import uk.gov.justice.digital.assessments.jpa.repositories.SubjectRepository
+import uk.gov.justice.digital.assessments.restclient.AssessmentUpdateRestClient
+import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.ValidationErrorDto
+import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
+import uk.gov.justice.digital.assessments.services.dto.OasysAnswers
+import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.UpdateClosedEpisodeException
+import java.time.LocalDateTime
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+@DisplayName("Assessment Service OASys Tests")
+class AssessmentServiceOASysTest {
+  private val assessmentRepository: AssessmentRepository = mockk()
+  private val episodeRepository: EpisodeRepository = mockk()
+  private val subjectRepository: SubjectRepository = mockk()
+  private val questionService: QuestionService = mockk()
+  private val courtCaseRestClient: CourtCaseRestClient = mockk()
+  private val episodeService: EpisodeService = mockk()
+  private val offenderService: OffenderService = mockk()
+  private val assessmentUpdateRestClient: AssessmentUpdateRestClient = mockk()
+
+  private val assessmentsService = AssessmentService(
+    assessmentRepository,
+    episodeRepository,
+    subjectRepository,
+    questionService,
+    episodeService,
+    courtCaseRestClient,
+    assessmentUpdateRestClient,
+    offenderService
+  )
+
+  private val assessmentUuid = UUID.randomUUID()
+  private val assessmentId = 1L
+  private val assessmentType = AssessmentType.SHORT_FORM_PSR
+
+  private val oasysOffenderPk = 1L
+  private val oasysSetPk = 1L
+
+  private val episodeId1 = 1L
+  private val episodeId2 = 2L
+
+  private val episodeUuid = UUID.randomUUID()
+
+  private val existingQuestionUuid = UUID.randomUUID()
+
+  private val question1Uuid = UUID.randomUUID()
+  private val question2Uuid = UUID.randomUUID()
+  private val question3Uuid = UUID.randomUUID()
+  private val answer1Uuid = UUID.randomUUID()
+  private val answer2Uuid = UUID.randomUUID()
+  private val answer3Uuid = UUID.randomUUID()
+
+  @Test
+  fun `update OASys if OASysSet stored against episode`() {
+      setupQuestionCodes()
+
+      val episode = AssessmentEpisodeEntity(
+        episodeId = episodeId1,
+        assessmentType = AssessmentType.SHORT_FORM_PSR,
+        oasysSetPk = oasysSetPk
+      )
+
+      every { assessmentUpdateRestClient.updateAssessment(oasysOffenderPk, oasysSetPk, assessmentType, any()) } returns UpdateAssessmentAnswersResponseDto()
+      assessmentsService.updateOASysAssessment(oasysOffenderPk, episode)
+      verify(exactly = 1) { assessmentUpdateRestClient.updateAssessment(oasysOffenderPk, oasysSetPk, assessmentType, any()) }
+    }
+
+  @Test
+  fun `don't update OASys if no OASysSet stored against episode`() {
+      setupQuestionCodes()
+
+      val episode = AssessmentEpisodeEntity(
+        oasysSetPk = oasysSetPk
+      )
+
+      every { assessmentUpdateRestClient.updateAssessment(oasysOffenderPk, oasysSetPk, assessmentType, any()) } returns UpdateAssessmentAnswersResponseDto()
+      assessmentsService.updateOASysAssessment(oasysOffenderPk, episode)
+      verify(exactly = 0) { assessmentUpdateRestClient.updateAssessment(oasysOffenderPk, oasysSetPk, assessmentType, any()) }
+    }
+
+  @Test
+  fun `create Oasys Answer from free text answer`() {
+      val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
+      val result = OasysAnswers.mapOasysAnswer(mapping, listOf("Free Text"), "radios")[0]
+      assertThat(result.answer).isEqualTo("Free Text")
+      assertThat(result.logicalPage).isEqualTo(1)
+      assertThat(result.isStatic).isFalse()
+      assertThat(result.questionCode).isEqualTo("R1.3")
+      assertThat(result.sectionCode).isEqualTo("1")
+    }
+
+  @Test
+  fun `create Oasys Answer with correct date format`() {
+      val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
+      val result = OasysAnswers.mapOasysAnswer(mapping, listOf("1975-01-20T00:00:00.000Z"), "date")[0]
+      assertThat(result.answer).isEqualTo("20/01/1975")
+    }
+
+  @Test
+  fun `returns validation errors from OASys`() {
+      val answers = mutableMapOf(
+        existingQuestionUuid to AnswerEntity(listOf("free text", "fruit loops", "biscuits"))
+      )
+      val assessment = assessmentEntityWithOasysOffender(answers)
+
+      val oaSysMappings = mutableListOf<OASysMappingEntity>()
+      val question = QuestionSchemaEntity(
+        questionSchemaId = 9,
+        questionSchemaUuid = existingQuestionUuid,
+        questionCode = "question",
+        questionText = "favourite breakfast cereal?",
+        oasysMappings = oaSysMappings
+      )
+      oaSysMappings.add(
+        OASysMappingEntity(
+          mappingId = 1,
+          sectionCode = "section1",
+          logicalPage = null,
+          questionCode = "Q1",
+          questionSchema = question
+        )
+      )
+
+      every { questionService.getAllQuestions() } returns QuestionSchemaEntities(listOf(question))
+      every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
+      every { assessmentRepository.save(any()) } returns null // should save when errors?
+      val oasysError = UpdateAssessmentAnswersResponseDto(
+        7777,
+        setOf(
+          ValidationErrorDto("section1", null, "Q1", "OOPS", "NO", false)
+        )
+      )
+      every { assessmentUpdateRestClient.updateAssessment(any(), any(), any(), any(), any(), any()) } returns oasysError
+      // Christ, what a lot of set up
+
+      // Apply the update
+      val updatedAnswers = UpdateAssessmentEpisodeDto(
+        mapOf(existingQuestionUuid to listOf("fruit loops", "custard"))
+      )
+      val episodeDto = assessmentsService.updateEpisode(assessmentUuid, episodeUuid, updatedAnswers)
+
+      // Updated answers in returned DTO
+      assertThat(episodeDto.answers).hasSize(1)
+      with(episodeDto.answers[existingQuestionUuid]!!) {
+        assertThat(size).isEqualTo(2)
+        assertThat(this).containsAll(listOf("fruit loops", "custard"))
+      }
+
+      // But also errors!
+      assertThat(episodeDto.errors).hasSize(1)
+      with(episodeDto.errors!![existingQuestionUuid]!!) {
+        assertThat(size).isEqualTo(1)
+        assertThat(this).contains("NO")
+      }
+    }
+
+  private fun setupQuestionCodes() {
+    val dummy = AnswerSchemaGroupEntity(answerSchemaId = 99)
+
+    val yes = AnswerSchemaEntity(answerSchemaId = 1, answerSchemaUuid = answer1Uuid, value = "YES", answerSchemaGroup = dummy)
+    val maybe = AnswerSchemaEntity(answerSchemaId = 2, answerSchemaUuid = answer2Uuid, value = "MAYBE", answerSchemaGroup = dummy)
+    val no = AnswerSchemaEntity(answerSchemaId = 3, answerSchemaUuid = answer3Uuid, value = "NO", answerSchemaGroup = dummy)
+
+    val group1 = AnswerSchemaGroupEntity(answerSchemaId = 1, answerSchemaEntities = listOf(yes))
+    val group2 = AnswerSchemaGroupEntity(answerSchemaId = 2, answerSchemaEntities = listOf(maybe, no))
+
+    every { questionService.getAllQuestions() } returns QuestionSchemaEntities(
+      listOf(
+        QuestionSchemaEntity(questionSchemaId = 1, questionSchemaUuid = question1Uuid, questionCode = "Q1", answerSchemaGroup = group1),
+        QuestionSchemaEntity(questionSchemaId = 2, questionSchemaUuid = question2Uuid, questionCode = "Q2", answerSchemaGroup = group2),
+        QuestionSchemaEntity(questionSchemaId = 3, questionSchemaUuid = question3Uuid)
+      )
+    )
+  }
+
+  private fun assessmentEntityWithOasysOffender(answers: MutableMap<UUID, AnswerEntity>): AssessmentEntity {
+    val subject = SubjectEntity(oasysOffenderPk = 9999)
+    val episodes = mutableListOf<AssessmentEpisodeEntity>()
+    val assessment = AssessmentEntity(
+      assessmentId = assessmentId,
+      episodes = episodes,
+      subject_ = mutableListOf(subject)
+    )
+
+    episodes.add(
+      AssessmentEpisodeEntity(
+        episodeUuid = episodeUuid,
+        episodeId = episodeId2,
+        assessment = assessment,
+        assessmentType = AssessmentType.SHORT_FORM_PSR,
+        changeReason = "Change of Circs 2",
+        oasysSetPk = 7777,
+        answers = answers
+      )
+    )
+
+    return assessment
+  }
+}


### PR DESCRIPTION
Work on how we take our ARN tabular answers and pass that across for the updates service to map into OASys.

Right now, we pass across a list of OASysAnswers, which contain section_code, logical_page (possibly null), question code, and the isStatic flag. On the updates side, the isStatic controls a detail of the mapping into the JSON for OASys. 

Our ARN tablular answers will look like this 
```
{
  ...
  "child-question-1-uuid": ["Bill", "Fred", "Bobby"]
  "child-question-2-uuid": [12, 15, 9] 
  ...
}
```
Our answers are arranged in a columnar fashion, rather than by rows. To pass into OASys, we want a structure that looks like 
```
{
"section": "CHILDREN",
"child": 1,
"results": [
  {   "fieldname": "action",		"fieldvalue": "create"	},
  {   "fieldname": "child_name",	"fieldvalue": "Bill"	},
  {   "fieldname": "age",		"fieldvalue":12		}
 ]
},
{
"section": "CHILDREN",
"child": 2,
"results": [
  {   "fieldname": "action",		"fieldvalue": "create"	},
  {   "fieldname": "child_name",	"fieldvalue": "Fred"	},
  {   "fieldname": "age",		"fieldvalue":15		}
 ]
},
...
```

This is similar to, but not quite the same as the existing mapping for static and dynamic fields. I'm trying to work out whether the we can get away with an isTabular flag or whether we need to split them out into a separate collection. 

We can pick up which bits of the data are tabular from the questions - see https://github.com/ministryofjustice/hmpps-assessments-api/pull/141 for context. [The changes on the update side were smallish](https://github.com/ministryofjustice/offender-assessments-updates/pull/37) and didn't require an API change. The work on this side is relatively straightforward too 

* Identify which tables might be in play for the whole set of answers
* Table-by-table, we fetch the relevant questions, and extract their associated answers from the set.
  * Shape those answers into OasysAnswers. 
* That done, we process the remaining answers as we did before.
* Pass OasysAnswers across to the update service to apply them to OASys


