### PR TITLE
ARN-363  endpoint for updating a table row

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
@@ -125,6 +125,27 @@ class AssessmentController(val assessmentService: AssessmentService) {
     )
   }
 
+  @RequestMapping(path = ["/assessments/{assessmentUuid}/episodes/{episodeUuid}/{tableName}/{index}"], method = [RequestMethod.POST])
+  @Operation(description = "adds a row to a table answer")
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "OK"),
+      ApiResponse(responseCode = "401", description = "Invalid JWT Token"),
+      ApiResponse(responseCode = "422", description = "The update couldn't be processed")
+    ]
+  )
+  fun updateAssessmentEpisodeTableRow(
+    @Parameter(description = "Assessment UUID", required = true, example = "1234") @PathVariable assessmentUuid: UUID,
+    @Parameter(description = "Episode UUID", required = true) @PathVariable episodeUuid: UUID,
+    @Parameter(description = "Table Name", required = true) @PathVariable tableName: String,
+    @Parameter(description = "Row index", required = true) @PathVariable index: Int,
+    @Parameter(description = "Updated Row", required = true) @RequestBody episodeAnswers: UpdateAssessmentEpisodeDto
+  ): ResponseEntity<AssessmentEpisodeDto> {
+    return updateResponse(
+      assessmentService.updateEpisodeTableRow(assessmentUuid, episodeUuid, tableName, index, episodeAnswers)
+    )
+  }
+
   @RequestMapping(path = ["/assessments/{assessmentUuid}/episodes/current"], method = [RequestMethod.POST])
   @Operation(description = "updates the answers for the current episode")
   @ApiResponses(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -210,6 +210,7 @@ class AssessmentService(
     return updateEpisode(episode, updatedEpisodeAnswers)
   }
 
+  @Transactional
   fun addEpisodeTableRow(
     assessmentUuid: UUID,
     episodeUuid: UUID,
@@ -225,6 +226,7 @@ class AssessmentService(
     }
   }
 
+  @Transactional
   fun updateEpisodeTableRow(
     assessmentUuid: UUID,
     episodeUuid: UUID,
@@ -244,7 +246,6 @@ class AssessmentService(
     }
   }
 
-  @Transactional
   private fun modifyEpisodeTableRow(
     assessmentUuid: UUID,
     episodeUuid: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -32,6 +32,8 @@ import java.time.LocalDateTime
 import java.util.UUID
 import javax.transaction.Transactional
 
+typealias TableAnswers = Map<UUID, Collection<String>>
+
 @Service
 class AssessmentService(
   private val assessmentRepository: AssessmentRepository,
@@ -247,7 +249,7 @@ class AssessmentService(
     assessmentUuid: UUID,
     episodeUuid: UUID,
     tableName: String,
-    modifyFn: (Map<UUID, Collection<String>>) -> Map<UUID, Collection<String>>
+    modifyFn: (TableAnswers) -> TableAnswers
   ): AssessmentEpisodeDto {
     val tableQuestions = questionService.getAllGroupQuestions(tableName)
     if (tableQuestions.isEmpty())
@@ -264,7 +266,7 @@ class AssessmentService(
   private fun grabExistingTableAnswers(
     episode: AssessmentEpisodeEntity,
     tableQuestions: QuestionSchemaEntities
-  ): Map<UUID, Collection<String>> {
+  ): TableAnswers {
     val existingTable = mutableMapOf<UUID, Collection<String>>()
 
     for (questionUuid in tableQuestions.map { it.questionSchemaUuid }) {
@@ -276,9 +278,9 @@ class AssessmentService(
   }
 
   private fun extendTableAnswers(
-    existingTable: Map<UUID, Collection<String>>,
-    newTableRow: Map<UUID, Collection<String>>
-  ): Map<UUID, Collection<String>> {
+    existingTable: TableAnswers,
+    newTableRow: TableAnswers
+  ): TableAnswers {
     val updatedTable = mutableMapOf<UUID, Collection<String>>()
 
     for ((id, answers) in existingTable) {
@@ -291,10 +293,10 @@ class AssessmentService(
   }
 
   private fun updateTableAnswers(
-    existingTable: Map<UUID, Collection<String>>,
+    existingTable: TableAnswers,
     index: Int,
-    updatedTableRow: Map<UUID, Collection<String>>
-  ): Map<UUID, Collection<String>> {
+    updatedTableRow: TableAnswers
+  ): TableAnswers {
     val updatedTable = mutableMapOf<UUID, Collection<String>>()
 
     for ((id, answers) in existingTable) {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -3,13 +3,10 @@ package uk.gov.justice.digital.assessments.services
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.ExtendWith
-import uk.gov.justice.digital.assessments.api.CreateAssessmentDto
-import uk.gov.justice.digital.assessments.api.OffenderDto
 import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerEntity
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaEntity
@@ -17,18 +14,12 @@ import uk.gov.justice.digital.assessments.jpa.entities.AnswerSchemaGroupEntity
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEntity
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
-import uk.gov.justice.digital.assessments.jpa.entities.OASysMappingEntity
 import uk.gov.justice.digital.assessments.jpa.entities.QuestionSchemaEntity
-import uk.gov.justice.digital.assessments.jpa.entities.SubjectEntity
 import uk.gov.justice.digital.assessments.jpa.repositories.AssessmentRepository
 import uk.gov.justice.digital.assessments.jpa.repositories.EpisodeRepository
 import uk.gov.justice.digital.assessments.jpa.repositories.SubjectRepository
 import uk.gov.justice.digital.assessments.restclient.AssessmentUpdateRestClient
 import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
-import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
-import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.ValidationErrorDto
-import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
-import uk.gov.justice.digital.assessments.services.dto.OasysAnswers
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.UpdateClosedEpisodeException
 import java.time.LocalDateTime
@@ -478,6 +469,7 @@ class AssessmentServiceTest {
     fun setup() {
       every { assessmentRepository.save(any()) } returns null
       every { questionService.getAllGroupQuestions("children_at_risk") } returns childTableQuestions
+      every { questionService.getAllGroupQuestions("nonsense_table") } returns QuestionSchemaEntities(emptyList())
     }
 
     @Test
@@ -572,6 +564,138 @@ class AssessmentServiceTest {
         assertThat(size).isEqualTo(2)
         assertThat(first()).isEqualTo("child address 1")
         assertThat(last()).isEqualTo("")
+      }
+    }
+
+    @Test
+    fun `update first row of table`() {
+      val answers = mutableMapOf(
+        question1Uuid to AnswerEntity("some free text"),
+        question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
+        question3Uuid to AnswerEntity("not mapped to oasys"),
+        childQuestion1 to AnswerEntity(listOf("name of child 1", "child name 2")),
+        childQuestion2 to AnswerEntity(listOf("address of child 1", "child address 2"))
+      )
+      every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessmentEntity(answers)
+
+      val tableAnswers = UpdateAssessmentEpisodeDto(
+        mapOf(
+          childQuestion1 to listOf("child name 1"),
+          childQuestion2 to listOf("child address 1"))
+      )
+
+      val episodeDto = assessmentsService.updateEpisodeTableRow(assessmentUuid, episodeUuid, "children_at_risk", 0, tableAnswers)
+
+      assertThat(episodeDto.answers).hasSize(5)
+      with(episodeDto.answers[childQuestion1]!!) {
+        assertThat(size).isEqualTo(2)
+        assertThat(first()).isEqualTo("child name 1")
+        assertThat(last()).isEqualTo("child name 2")
+      }
+
+      with(episodeDto.answers[childQuestion2]!!) {
+        assertThat(size).isEqualTo(2)
+        assertThat(first()).isEqualTo("child address 1")
+        assertThat(last()).isEqualTo("child address 2")
+      }
+    }
+
+    @Test
+    fun `update last row of table`() {
+      val answers = mutableMapOf(
+        question1Uuid to AnswerEntity("some free text"),
+        question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
+        question3Uuid to AnswerEntity("not mapped to oasys"),
+        childQuestion1 to AnswerEntity(listOf("child name 1", "name of child 2")),
+        childQuestion2 to AnswerEntity(listOf("child address 1", ""))
+      )
+      every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessmentEntity(answers)
+
+      val tableAnswers = UpdateAssessmentEpisodeDto(
+        mapOf(
+          childQuestion1 to listOf("child name 2"),
+          childQuestion2 to listOf("child address 2"))
+      )
+
+      val episodeDto = assessmentsService.updateEpisodeTableRow(assessmentUuid, episodeUuid, "children_at_risk", 1, tableAnswers)
+
+      assertThat(episodeDto.answers).hasSize(5)
+      with(episodeDto.answers[childQuestion1]!!) {
+        assertThat(size).isEqualTo(2)
+        assertThat(first()).isEqualTo("child name 1")
+        assertThat(last()).isEqualTo("child name 2")
+      }
+
+      with(episodeDto.answers[childQuestion2]!!) {
+        assertThat(size).isEqualTo(2)
+        assertThat(first()).isEqualTo("child address 1")
+        assertThat(last()).isEqualTo("child address 2")
+      }
+    }
+
+    @Test
+    fun `update middle row of table`() {
+      val answers = mutableMapOf(
+        question1Uuid to AnswerEntity("some free text"),
+        question2Uuid to AnswerEntity("1975-01-20T00:00:00.000Z"),
+        question3Uuid to AnswerEntity("not mapped to oasys"),
+        childQuestion1 to AnswerEntity(listOf("child name 1", "name of child 2", "child name 3")),
+        childQuestion2 to AnswerEntity(listOf("child address 1", "address of child 2", "child address 3"))
+      )
+      every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessmentEntity(answers)
+
+      val tableAnswers = UpdateAssessmentEpisodeDto(
+        mapOf(
+          childQuestion1 to listOf("child name 2"),
+          childQuestion2 to listOf("child address 2"))
+      )
+
+      val episodeDto = assessmentsService.updateEpisodeTableRow(assessmentUuid, episodeUuid, "children_at_risk", 1, tableAnswers)
+
+      assertThat(episodeDto.answers).hasSize(5)
+      with(episodeDto.answers[childQuestion1]!!) {
+        assertThat(size).isEqualTo(3)
+        assertThat(first()).isEqualTo("child name 1")
+        assertThat(toList()[1]).isEqualTo("child name 2")
+        assertThat(last()).isEqualTo("child name 3")
+      }
+
+      with(episodeDto.answers[childQuestion2]!!) {
+        assertThat(size).isEqualTo(3)
+        assertThat(first()).isEqualTo("child address 1")
+        assertThat(toList()[1]).isEqualTo("child address 2")
+        assertThat(last()).isEqualTo("child address 3")
+      }
+    }
+
+    @Test
+    fun `fail on bad table name`() {
+      assertThatThrownBy {
+        assessmentsService.addEpisodeTableRow(
+          assessmentUuid,
+          episodeUuid,
+          "nonsense_table",
+          UpdateAssessmentEpisodeDto(emptyMap()))
+      }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("No questions found for table nonsense_table")
+    }
+
+    @Test
+    fun `fail on bad index`() {
+      every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessmentEntity(mutableMapOf())
+
+      for (index in listOf(-3, -1, 0, 5)) {
+        assertThatThrownBy {
+          assessmentsService.updateEpisodeTableRow(
+            assessmentUuid,
+            episodeUuid,
+            "children_at_risk",
+            index,
+            UpdateAssessmentEpisodeDto(emptyMap()))
+        }
+          .isInstanceOf(IllegalStateException::class.java)
+          .hasMessage("Bad index $index for table children_at_risk")
       }
     }
   }


### PR DESCRIPTION
Adds /assessments/{assessmentUuid}/episodes/{episodeUuid}/{tableName}/{index} endpoint, for updating an existing row in a table

* AssessmentController.updateAssessmentEpisodeTableRow, endpoint which forwards to ...
* AssessmentService.updateEpisodeTableRow where we do that actual work.

Much of the implementation is charge with #152. That PR also has details of how the tables are laid out in the JSON. 

