### PR TITLE
Arn 419 user area header broadcasting

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/ReferenceDataController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/ReferenceDataController.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiInvalid
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknownException
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.UpdateClosedEpisodeException
+import uk.gov.justice.digital.assessments.utils.RequestData
 import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
 
 @ControllerAdvice
@@ -122,6 +123,13 @@ class ControllerAdvice {
       e.message
     )
     return ResponseEntity(ErrorResponse(status = 401, developerMessage = e.message), HttpStatus.UNAUTHORIZED)
+  }
+
+  @ExceptionHandler(RequestData.Companion.UserAreaHeaderIsMandatoryException::class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  fun handle(e: RequestData.Companion.UserAreaHeaderIsMandatoryException): ResponseEntity<ErrorResponse?> {
+    log.info("UserAreaHeaderIsMandatoryException: {}", e.message)
+    return ResponseEntity(ErrorResponse(status = 400, developerMessage = e.message), HttpStatus.BAD_REQUEST)
   }
 
   @ExceptionHandler(ExternalApiForbiddenException::class)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
@@ -15,6 +15,11 @@ import uk.gov.justice.digital.assessments.restclient.assessmentapi.OASysAssessme
 import uk.gov.justice.digital.assessments.restclient.assessmentapi.RefElementDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OASysErrorResponse
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.OASysClientException
+import uk.gov.justice.digital.assessments.services.exceptions.ReferenceDataAuthorisationException
+import uk.gov.justice.digital.assessments.services.exceptions.ReferenceDataInvalidRequestException
+import uk.gov.justice.digital.assessments.utils.RequestData
 
 @Component
 class AssessmentApiRestClient {
@@ -54,7 +59,6 @@ class AssessmentApiRestClient {
   fun getFilteredReferenceData(
     oasysSetPk: Long,
     oasysUserCode: String = "STUARTWHITLAM",
-    oasysAreaCode: String = "WWS",
     offenderPk: Long?,
     assessmentType: String,
     sectionCode: String,
@@ -66,7 +70,7 @@ class AssessmentApiRestClient {
       .post(
         path,
         FilteredReferenceDataDto(
-          oasysSetPk, oasysUserCode, oasysAreaCode, offenderPk, assessmentType, sectionCode, fieldName, parentList
+          oasysSetPk, oasysUserCode, RequestData.getAreaCode(), offenderPk, assessmentType, sectionCode, fieldName, parentList
         )
       )
       .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
@@ -15,10 +15,6 @@ import uk.gov.justice.digital.assessments.restclient.assessmentapi.OASysAssessme
 import uk.gov.justice.digital.assessments.restclient.assessmentapi.RefElementDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OASysErrorResponse
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.OASysClientException
-import uk.gov.justice.digital.assessments.services.exceptions.ReferenceDataAuthorisationException
-import uk.gov.justice.digital.assessments.services.exceptions.ReferenceDataInvalidRequestException
 import uk.gov.justice.digital.assessments.utils.RequestData
 
 @Component

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
@@ -16,6 +16,12 @@ import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateO
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
+import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
+import uk.gov.justice.digital.assessments.services.exceptions.OASysClientException
+import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentDto
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentResponse
+import uk.gov.justice.digital.assessments.utils.RequestData
 
 @Component
 class AssessmentUpdateRestClient {
@@ -30,9 +36,9 @@ class AssessmentUpdateRestClient {
   fun createOasysOffender(
     crn: String,
     user: String = "STUARTWHITLAM",
-    area: String = "WWS",
     deliusEvent: Long? = 123456
   ): Long? {
+    val area = RequestData.getAreaCode()
     log.info("Creating offender in OASys for crn: $crn, area: $area, user: $user, delius event: $deliusEvent")
     val path = "/offenders"
     return webClient
@@ -55,9 +61,9 @@ class AssessmentUpdateRestClient {
   fun createAssessment(
     offenderPK: Long,
     assessmentType: AssessmentType,
-    user: String = "STUARTWHITLAM",
-    area: String = "WWS",
+    user: String = "STUARTWHITLAM"
   ): Long? {
+    val area = RequestData.getAreaCode()
     log.info("Creating Assessment of type $assessmentType in OASys for offender: $offenderPK, area: $area, user: $user")
     val path = "/assessments"
     return webClient
@@ -92,9 +98,9 @@ class AssessmentUpdateRestClient {
     oasysSetPk: Long,
     assessmentType: AssessmentType,
     answers: Set<OasysAnswer>,
-    user: String = "STUARTWHITLAM",
-    area: String = "WWS",
+    user: String = "STUARTWHITLAM"
   ): UpdateAssessmentAnswersResponseDto? {
+    val area = RequestData.getAreaCode()
     log.info("Updating answers for Assessment $oasysSetPk in OASys for offender: $offenderPK, area: $area, user: $user, answers: $answers")
     val path = "/assessments"
     return webClient
@@ -129,9 +135,9 @@ class AssessmentUpdateRestClient {
     oasysSetPk: Long,
     assessmentType: AssessmentType,
     ignoreWarnings: Boolean = true,
-    user: String = "STUARTWHITLAM",
-    area: String = "WWS"
+    user: String = "STUARTWHITLAM"
   ): UpdateAssessmentAnswersResponseDto? {
+    val area = RequestData.getAreaCode()
     log.info("Completing Assessment $oasysSetPk in OASys for offender: $offenderPK, area: $area, user: $user")
     val path = "/assessments/complete"
     return webClient

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
@@ -16,11 +16,6 @@ import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateO
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
-import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
-import uk.gov.justice.digital.assessments.services.exceptions.OASysClientException
-import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
-import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentDto
-import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentResponse
 import uk.gov.justice.digital.assessments.utils.RequestData
 
 @Component

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/utils/RequestData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/utils/RequestData.kt
@@ -20,6 +20,7 @@ class RequestData(excludeUris: String?) : HandlerInterceptor {
     request.setAttribute("startTime", LocalDateTime.now().toString())
     MDC.clear()
     MDC.put(USER_ID_HEADER, initialiseUserId(request))
+    MDC.put(USER_AREA_HEADER, request.getHeader(USER_AREA_HEADER_NAME))
 
     if (excludeUriRegex.matcher(request.requestURI).matches()) {
       MDC.put(SKIP_LOGGING, "true")
@@ -54,11 +55,17 @@ class RequestData(excludeUris: String?) : HandlerInterceptor {
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
-    private const val ANONYMOUS = "anonymous"
     const val SKIP_LOGGING = "skipLogging"
     const val REQUEST_DURATION = "duration"
     const val RESPONSE_STATUS = "status"
     const val USER_ID_HEADER = "userId"
+    const val USER_AREA_HEADER = "userArea"
+    const val USER_AREA_HEADER_NAME = "x-user-area"
     val isLoggingAllowed: Boolean = "true" != MDC.get(SKIP_LOGGING)
+
+    fun getAreaCode(): String {
+      return MDC.get(USER_AREA_HEADER) ?: throw UserAreaHeaderIsMandatoryException("Area Code header is Mandatory")
+    }
+    class UserAreaHeaderIsMandatoryException(msg: String?) : RuntimeException(msg)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/utils/RequestData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/utils/RequestData.kt
@@ -64,7 +64,7 @@ class RequestData(excludeUris: String?) : HandlerInterceptor {
     val isLoggingAllowed: Boolean = "true" != MDC.get(SKIP_LOGGING)
 
     fun getAreaCode(): String {
-      return MDC.get(USER_AREA_HEADER) ?: throw UserAreaHeaderIsMandatoryException("Area Code header is Mandatory")
+      return MDC.get(USER_AREA_HEADER) ?: throw UserAreaHeaderIsMandatoryException("Area Code Header is mandatory")
     }
     class UserAreaHeaderIsMandatoryException(msg: String?) : RuntimeException(msg)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.assessments.api.AssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.api.AssessmentSubjectDto
 import uk.gov.justice.digital.assessments.api.CreateAssessmentDto
 import uk.gov.justice.digital.assessments.api.CreateAssessmentEpisodeDto
+import uk.gov.justice.digital.assessments.api.ErrorResponse
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 import uk.gov.justice.digital.assessments.utils.RequestData
@@ -21,8 +22,15 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @SqlGroup(
-  Sql(scripts = ["classpath:assessments/before-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)),
-  Sql(scripts = ["classpath:assessments/after-test.sql"], config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED), executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+  Sql(
+    scripts = ["classpath:assessments/before-test.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED)
+  ),
+  Sql(
+    scripts = ["classpath:assessments/after-test.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+  )
 )
 @AutoConfigureWebTestClient(timeout = "50000")
 class AssessmentControllerCreateTest : IntegrationTest() {
@@ -36,6 +44,26 @@ class AssessmentControllerCreateTest : IntegrationTest() {
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `should return bad request when no user area header is set when creating court assessment`() {
+      webTestClient.post().uri("/assessments")
+        .bodyValue(
+          CreateAssessmentDto(
+            courtCode = "SHF06",
+            caseNumber = "668911253",
+            assessmentType = AssessmentType.SHORT_FORM_PSR
+          )
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody<ErrorResponse>()
+        .consumeWith {
+          assertThat(it.responseBody?.status).isEqualTo(400)
+          assertThat(it.responseBody?.developerMessage).isEqualTo("Area Code Header is mandatory")
+        }
     }
 
     @Test
@@ -84,6 +112,26 @@ class AssessmentControllerCreateTest : IntegrationTest() {
     }
 
     @Test
+    fun `should return bad request when no user area header is set when creating assessment from delius`() {
+      webTestClient.post().uri("/assessments")
+        .bodyValue(
+          CreateAssessmentDto(
+            crn = crn,
+            deliusEventId = eventID,
+            assessmentType = AssessmentType.SHORT_FORM_PSR
+          )
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody<ErrorResponse>()
+        .consumeWith {
+          assertThat(it.responseBody?.status).isEqualTo(400)
+          assertThat(it.responseBody?.developerMessage).isEqualTo("Area Code Header is mandatory")
+        }
+    }
+
+    @Test
     fun `creating a new assessment from crn and delius event id returns assessment`() {
 
       val assessment = createDeliusAssessment(crn, eventID)
@@ -126,7 +174,13 @@ class AssessmentControllerCreateTest : IntegrationTest() {
   }
 
   private fun createDeliusAssessment(crn: String, deliusId: Long): AssessmentDto {
-    return createDeliusAssessment(CreateAssessmentDto(crn = crn, deliusEventId = deliusId, assessmentType = AssessmentType.SHORT_FORM_PSR))
+    return createDeliusAssessment(
+      CreateAssessmentDto(
+        crn = crn,
+        deliusEventId = deliusId,
+        assessmentType = AssessmentType.SHORT_FORM_PSR
+      )
+    )
   }
 
   private fun createDeliusAssessment(cad: CreateAssessmentDto): AssessmentDto {
@@ -143,7 +197,13 @@ class AssessmentControllerCreateTest : IntegrationTest() {
   }
 
   private fun createCourtAssessment(courtCode: String, caseNumber: String): AssessmentDto {
-    return createCourtAssessment(CreateAssessmentDto(courtCode = courtCode, caseNumber = caseNumber, assessmentType = AssessmentType.SHORT_FORM_PSR))
+    return createCourtAssessment(
+      CreateAssessmentDto(
+        courtCode = courtCode,
+        caseNumber = caseNumber,
+        assessmentType = AssessmentType.SHORT_FORM_PSR
+      )
+    )
   }
 
   private fun createCourtAssessment(cad: CreateAssessmentDto): AssessmentDto {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.assessments.api.CreateAssessmentDto
 import uk.gov.justice.digital.assessments.api.CreateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import uk.gov.justice.digital.assessments.utils.RequestData
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -131,6 +132,7 @@ class AssessmentControllerCreateTest : IntegrationTest() {
   private fun createDeliusAssessment(cad: CreateAssessmentDto): AssessmentDto {
     val assessment = webTestClient.post().uri("/assessments")
       .bodyValue(cad)
+      .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
       .headers(setAuthorisation())
       .exchange()
       .expectStatus().isOk
@@ -147,6 +149,7 @@ class AssessmentControllerCreateTest : IntegrationTest() {
   private fun createCourtAssessment(cad: CreateAssessmentDto): AssessmentDto {
     val assessment = webTestClient.post().uri("/assessments")
       .bodyValue(cad)
+      .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
       .headers(setAuthorisation())
       .exchange()
       .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.assessments.api.AssessmentSubjectDto
 import uk.gov.justice.digital.assessments.api.ErrorResponse
 import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import uk.gov.justice.digital.assessments.utils.RequestData
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -175,6 +176,7 @@ class AssessmentControllerTest : IntegrationTest() {
     @Test
     fun `complete assessment episode returns episode`() {
       val assessmentEpisode = webTestClient.post().uri("/assessments/$assessmentUuid/complete")
+        .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus().isOk
@@ -201,6 +203,7 @@ class AssessmentControllerTest : IntegrationTest() {
     fun `complete assessment episode with errors returns assessment level errors`() {
       val assessmentErrorsUUID = UUID.fromString("aa47e6c4-e41f-467c-95e7-fcf5ffd422f5")
       val assessmentEpisode = webTestClient.post().uri("/assessments/$assessmentErrorsUUID/complete")
+        .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
@@ -213,6 +213,19 @@ class AssessmentControllerTest : IntegrationTest() {
       assertThat(assessmentEpisode.ended).isNull()
       assertThat(assessmentEpisode.assessmentErrors).hasSize(1)
     }
+
+    @Test
+    fun `should return bad request when no user area header is set when completing assessment`() {
+      webTestClient.post().uri("/assessments/$assessmentUuid/complete")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody<ErrorResponse>()
+        .consumeWith {
+          assertThat(it.responseBody?.status).isEqualTo(400)
+          assertThat(it.responseBody?.developerMessage).isEqualTo("Area Code Header is mandatory")
+        }
+    }
   }
 
   private fun fetchAssessmentSubject(assessmentUuid: String): AssessmentSubjectDto {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/ReferenceDataControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/ReferenceDataControllerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.http.HttpHeaders
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import org.springframework.test.context.jdbc.SqlGroup
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.assessments.api.ErrorResponse
 import uk.gov.justice.digital.assessments.api.FilteredReferenceDataRequest
 import uk.gov.justice.digital.assessments.restclient.assessmentapi.RefElementDto
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import uk.gov.justice.digital.assessments.utils.RequestData
 import java.util.UUID
 
 @SqlGroup(
@@ -51,6 +53,7 @@ class ReferenceDataControllerTest : IntegrationTest() {
             mapOf(validParentQuestionUuid to "test")
           )
         )
+        .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus().isOk
@@ -114,6 +117,7 @@ class ReferenceDataControllerTest : IntegrationTest() {
             mapOf(validParentQuestionUuid to "test")
           )
         )
+        .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus().isNotFound
@@ -135,6 +139,7 @@ class ReferenceDataControllerTest : IntegrationTest() {
             mapOf(validParentQuestionUuid to "test")
           )
         )
+        .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus().isUnauthorized
@@ -156,6 +161,7 @@ class ReferenceDataControllerTest : IntegrationTest() {
             mapOf(validParentQuestionUuid to "test")
           )
         )
+        .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus().isBadRequest
@@ -177,6 +183,7 @@ class ReferenceDataControllerTest : IntegrationTest() {
             mapOf(validParentQuestionUuid to "test")
           )
         )
+        .header(RequestData.USER_AREA_HEADER_NAME, "WWS")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus().is5xxServerError

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.assessments.restclient
 
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
@@ -17,6 +18,11 @@ class AssessmentApiTest : IntegrationTest() {
   internal lateinit var assessmentApiRestClient: AssessmentApiRestClient
 
   val oasysSetPk = 1L
+
+  @BeforeEach
+  fun setup() {
+    MDC.put(USER_AREA_HEADER, "WWS")
+  }
 
   @Test
   fun `retrieve OASys Assessment`() {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.assessments.restclient
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiAuthorisationException
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiInvalidRequestException
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknownException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import uk.gov.justice.digital.assessments.utils.RequestData.Companion.USER_AREA_HEADER
 
 class AssessmentApiTest : IntegrationTest() {
   @Autowired
@@ -52,11 +54,11 @@ class AssessmentApiTest : IntegrationTest() {
 
   @Test
   fun `retrieve OASys filtered reference data`() {
+    MDC.put(USER_AREA_HEADER, "WWS")
     val returnedReferenceData =
       assessmentApiRestClient.getFilteredReferenceData(
         1,
         "TEST_USER",
-        "WWS",
         123456,
         "SHORT_FORM_PSR",
         "RSR",
@@ -72,7 +74,6 @@ class AssessmentApiTest : IntegrationTest() {
       assessmentApiRestClient.getFilteredReferenceData(
         2,
         "TEST_USER",
-        "WWS",
         123456,
         "SHORT_FORM_PSR",
         "RSR",
@@ -88,7 +89,6 @@ class AssessmentApiTest : IntegrationTest() {
       assessmentApiRestClient.getFilteredReferenceData(
         3,
         "TEST_USER",
-        "WWS",
         123456,
         "SHORT_FORM_PSR",
         "RSR",
@@ -104,7 +104,6 @@ class AssessmentApiTest : IntegrationTest() {
       assessmentApiRestClient.getFilteredReferenceData(
         4,
         "TEST_USER",
-        "WWS",
         123456,
         "SHORT_FORM_PSR",
         "RSR",
@@ -120,7 +119,6 @@ class AssessmentApiTest : IntegrationTest() {
       assessmentApiRestClient.getFilteredReferenceData(
         5,
         "TEST_USER",
-        "WWS",
         123456,
         "SHORT_FORM_PSR",
         "RSR",

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.assessments.restclient
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
@@ -10,6 +12,7 @@ import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknown
 import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
 import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import uk.gov.justice.digital.assessments.utils.RequestData
 
 class OASysUpdateClientTest : IntegrationTest() {
   @Autowired
@@ -28,6 +31,11 @@ class OASysUpdateClientTest : IntegrationTest() {
   val duplicateOffenderPk = 3L
   val serverErrorOffenderPk = 4L
   val validationErrorOffenderPk = 5L
+
+  @BeforeEach
+  fun setup() {
+    MDC.put(RequestData.USER_AREA_HEADER, "WWS")
+  }
 
   @Test
   fun `create OASys Offender`() {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceOASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceOASysTest.kt
@@ -69,7 +69,14 @@ class AssessmentUpdateServiceOASysTest {
 
   @Test
   fun `map Oasys answer from free text answer`() {
-    val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
+    val mapping = OASysMappingEntity(
+      sectionCode = "1",
+      questionCode = "R1.3",
+      logicalPage = 1,
+      fixed_field = false,
+      mappingId = 1,
+      questionSchema = QuestionSchemaEntity(questionSchemaId = 1)
+    )
 
     val result = OasysAnswers.mapOasysAnswers(mapping, listOf("Free Text"), "radios")[0]
 
@@ -82,7 +89,14 @@ class AssessmentUpdateServiceOASysTest {
 
   @Test
   fun `map Oasys answer with correct date format`() {
-    val mapping = OASysMappingEntity(sectionCode = "1", questionCode = "R1.3", logicalPage = 1, fixed_field = false, mappingId = 1, questionSchema = QuestionSchemaEntity(questionSchemaId = 1))
+    val mapping = OASysMappingEntity(
+      sectionCode = "1",
+      questionCode = "R1.3",
+      logicalPage = 1,
+      fixed_field = false,
+      mappingId = 1,
+      questionSchema = QuestionSchemaEntity(questionSchemaId = 1)
+    )
 
     val result = OasysAnswers.mapOasysAnswers(mapping, listOf("1975-01-20T00:00:00.000Z"), "date")[0]
 
@@ -133,8 +147,10 @@ class AssessmentUpdateServiceOASysTest {
     private val childQuestion1 = UUID.randomUUID()
     private val childQuestion2 = UUID.randomUUID()
 
-    private val childNameQuestion = makeQuestion(10, childQuestion1, "Name", "freetext", null, "children", null, "childname")
-    private val childAddressQuestion = makeQuestion(11, childQuestion2, "Address", "freetext", null, "children", null, "childaddress")
+    private val childNameQuestion =
+      makeQuestion(10, childQuestion1, "Name", "freetext", null, "children", null, "childname")
+    private val childAddressQuestion =
+      makeQuestion(11, childQuestion2, "Address", "freetext", null, "children", null, "childaddress")
 
     val allQuestions = QuestionSchemaEntities(
       listOf(
@@ -215,7 +231,14 @@ class AssessmentUpdateServiceOASysTest {
   @Test
   fun `update OASys if OASysSet stored against episode`() {
     every { questionService.getAllQuestions() } returns setupQuestionCodes()
-    every { assessmentUpdateRestClient.updateAssessment(oasysOffenderPk, oasysSetPk, assessmentType, any()) } returns UpdateAssessmentAnswersResponseDto()
+    every {
+      assessmentUpdateRestClient.updateAssessment(
+        oasysOffenderPk,
+        oasysSetPk,
+        assessmentType,
+        any()
+      )
+    } returns UpdateAssessmentAnswersResponseDto()
     every { questionService.getAllSectionQuestionsForQuestions(any()) } returns QuestionSchemaEntities(questionsList = emptyList())
 
     val update = UpdateAssessmentEpisodeDto(
@@ -232,7 +255,14 @@ class AssessmentUpdateServiceOASysTest {
   @Test
   fun `don't update OASys if no OASysSet stored against episode`() {
     every { questionService.getAllQuestions() } returns setupQuestionCodes()
-    every { assessmentUpdateRestClient.updateAssessment(oasysOffenderPk, oasysSetPk, assessmentType, any()) } returns UpdateAssessmentAnswersResponseDto()
+    every {
+      assessmentUpdateRestClient.updateAssessment(
+        oasysOffenderPk,
+        oasysSetPk,
+        assessmentType,
+        any()
+      )
+    } returns UpdateAssessmentAnswersResponseDto()
 
     val episode = AssessmentEpisodeEntity(
       oasysSetPk = oasysSetPk
@@ -282,7 +312,7 @@ class AssessmentUpdateServiceOASysTest {
         )
       )
     )
-    every { assessmentUpdateRestClient.updateAssessment(any(), any(), any(), any(), any(), any()) } returns oasysError
+    every { assessmentUpdateRestClient.updateAssessment(any(), any(), any(), any(), any()) } returns oasysError
     // Christ, what a lot of set up
 
     // Apply the update
@@ -340,9 +370,12 @@ class AssessmentUpdateServiceOASysTest {
   private fun setupQuestionCodes(): QuestionSchemaEntities {
     val dummy = AnswerSchemaGroupEntity(answerSchemaId = 99)
 
-    val yes = AnswerSchemaEntity(answerSchemaId = 1, answerSchemaUuid = answer1Uuid, value = "YES", answerSchemaGroup = dummy)
-    val maybe = AnswerSchemaEntity(answerSchemaId = 2, answerSchemaUuid = answer2Uuid, value = "MAYBE", answerSchemaGroup = dummy)
-    val no = AnswerSchemaEntity(answerSchemaId = 3, answerSchemaUuid = answer3Uuid, value = "NO", answerSchemaGroup = dummy)
+    val yes =
+      AnswerSchemaEntity(answerSchemaId = 1, answerSchemaUuid = answer1Uuid, value = "YES", answerSchemaGroup = dummy)
+    val maybe =
+      AnswerSchemaEntity(answerSchemaId = 2, answerSchemaUuid = answer2Uuid, value = "MAYBE", answerSchemaGroup = dummy)
+    val no =
+      AnswerSchemaEntity(answerSchemaId = 3, answerSchemaUuid = answer3Uuid, value = "NO", answerSchemaGroup = dummy)
 
     val group1 = AnswerSchemaGroupEntity(answerSchemaId = 1, answerSchemaEntities = listOf(yes))
     val group2 = AnswerSchemaGroupEntity(answerSchemaId = 2, answerSchemaEntities = listOf(maybe, no))

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/ReferenceDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/ReferenceDataServiceTest.kt
@@ -43,7 +43,7 @@ private val parentQuestionMapping = OASysMappingEntity(mappingId = 5678, questio
 class ReferenceDataServiceTest {
   @Test
   fun `returns reference data`() {
-    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any(), any()) } returns referenceData
+    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any()) } returns referenceData
 
     every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
     every { oaSysMappingRepository.findAllByQuestionSchema_QuestionSchemaUuidIn(any()) } returns listOf(questionMapping, parentQuestionMapping)
@@ -60,7 +60,7 @@ class ReferenceDataServiceTest {
 
   @Test
   fun `passes exceptions thrown by the assessments client`() {
-    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any(), any()) } throws Exception("Something went wrong in the client")
+    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any()) } throws Exception("Something went wrong in the client")
 
     every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
     every { oaSysMappingRepository.findAllByQuestionSchema_QuestionSchemaUuidIn(any()) } returns listOf(questionMapping, parentQuestionMapping)
@@ -77,7 +77,7 @@ class ReferenceDataServiceTest {
 
   @Test
   fun `throws when unable to find the selected episode`() {
-    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any(), any()) } returns referenceData
+    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any()) } returns referenceData
 
     every { assessmentRepository.findByAssessmentUuid(any()) } returns AssessmentEntity(episodes = mutableListOf())
     every { oaSysMappingRepository.findAllByQuestionSchema_QuestionSchemaUuidIn(any()) } returns listOf(questionMapping, parentQuestionMapping)
@@ -96,7 +96,7 @@ class ReferenceDataServiceTest {
 
   @Test
   fun `throws when unable to find the OASys mapping for the question`() {
-    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any(), any()) } returns referenceData
+    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any()) } returns referenceData
 
     every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
     every { oaSysMappingRepository.findAllByQuestionSchema_QuestionSchemaUuidIn(any()) } returns listOf(parentQuestionMapping)
@@ -115,7 +115,7 @@ class ReferenceDataServiceTest {
 
   @Test
   fun `throws when unable to find the OASys mapping for the parent question`() {
-    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any(), any()) } returns referenceData
+    every { assessmentApiRestClient.getFilteredReferenceData(any(), any(), any(), any(), any(), any(), any()) } returns referenceData
 
     every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
     every { oaSysMappingRepository.findAllByQuestionSchema_QuestionSchemaUuidIn(any()) } returns listOf(questionMapping)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/IntegrationTest.kt
@@ -12,10 +12,14 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.assessments.HmppsAssessmentApiApplication
 import uk.gov.justice.digital.assessments.JwtAuthHelper
+import uk.gov.justice.digital.assessments.utils.RequestData
 import java.time.Duration
 
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
-@SpringBootTest(classes = [HmppsAssessmentApiApplication::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+  classes = [HmppsAssessmentApiApplication::class],
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
 @ActiveProfiles(profiles = ["test"])
 abstract class IntegrationTest {
 
@@ -67,7 +71,10 @@ abstract class IntegrationTest {
     assessmentApiMockServer.stubGetAssessment()
   }
 
-  internal fun setAuthorisation(user: String = "offender-assessment-api", roles: List<String> = listOf()): (HttpHeaders) -> Unit {
+  internal fun setAuthorisation(
+    user: String = "offender-assessment-api",
+    roles: List<String> = listOf()
+  ): (HttpHeaders) -> Unit {
     val token = jwtHelper.createJwt(
       subject = user,
       scope = listOf("read"),
@@ -76,4 +83,5 @@ abstract class IntegrationTest {
     )
     return { it.set(HttpHeaders.AUTHORIZATION, "Bearer $token") }
   }
+
 }


### PR DESCRIPTION
We need to pass in the User Area in a Header from the frontend
And in the assessments-api we will get the new `USER_AREA_HEADER_NAME = "x-user-area"` store it on the MDC and use to call the downstream services that require this user area.
