### PR TITLE
Arn 246 error handling for external services

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
@@ -86,7 +86,7 @@ class ControllerAdvice {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   fun handle(e: ApiClientInvalidRequestException): ResponseEntity<ErrorResponse?> {
     log.error(
-      "InvalidRequestException for external client ${e.client} method ${e.method} and url ${e.url} with optional param ${e.extraParam}: {}",
+      "InvalidRequestException for external client ${e.client} method ${e.method} and url ${e.url}: {}",
       e.message
     )
     return ResponseEntity(ErrorResponse(status = 400, developerMessage = e.message), HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
@@ -11,11 +11,11 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import uk.gov.justice.digital.assessments.api.ErrorResponse
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientAuthorisationException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientForbiddenException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientInvalidRequestException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiAuthorisationException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiForbiddenException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiInvalidRequestException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknownException
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.UpdateClosedEpisodeException
 
@@ -68,23 +68,23 @@ class ControllerAdvice {
     return ResponseEntity(ErrorResponse(status = 400, developerMessage = e.message), HttpStatus.BAD_REQUEST)
   }
 
-  @ExceptionHandler(ApiClientEntityNotFoundException::class)
+  @ExceptionHandler(ExternalApiEntityNotFoundException::class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
-  fun handle(e: ApiClientEntityNotFoundException): ResponseEntity<ErrorResponse?> {
+  fun handle(e: ExternalApiEntityNotFoundException): ResponseEntity<ErrorResponse?> {
     log.info("ApiClientEntityNotFoundException for external client ${e.client} method ${e.method} and url ${e.url}: {}", e.message)
     return ResponseEntity(ErrorResponse(status = 404, developerMessage = e.message), HttpStatus.NOT_FOUND)
   }
 
-  @ExceptionHandler(ApiClientUnknownException::class)
+  @ExceptionHandler(ExternalApiUnknownException::class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-  fun handle(e: ApiClientUnknownException): ResponseEntity<ErrorResponse?> {
+  fun handle(e: ExternalApiUnknownException): ResponseEntity<ErrorResponse?> {
     log.error("ExternalClientUnknownException for external client ${e.client} method ${e.method} and url ${e.url}: {}", e.message)
     return ResponseEntity(ErrorResponse(status = 500, developerMessage = e.message), HttpStatus.INTERNAL_SERVER_ERROR)
   }
 
-  @ExceptionHandler(ApiClientInvalidRequestException::class)
+  @ExceptionHandler(ExternalApiInvalidRequestException::class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  fun handle(e: ApiClientInvalidRequestException): ResponseEntity<ErrorResponse?> {
+  fun handle(e: ExternalApiInvalidRequestException): ResponseEntity<ErrorResponse?> {
     log.error(
       "InvalidRequestException for external client ${e.client} method ${e.method} and url ${e.url}: {}",
       e.message
@@ -92,9 +92,9 @@ class ControllerAdvice {
     return ResponseEntity(ErrorResponse(status = 400, developerMessage = e.message), HttpStatus.BAD_REQUEST)
   }
 
-  @ExceptionHandler(ApiClientAuthorisationException::class)
+  @ExceptionHandler(ExternalApiAuthorisationException::class)
   @ResponseStatus(HttpStatus.UNAUTHORIZED)
-  fun handle(e: ApiClientAuthorisationException): ResponseEntity<ErrorResponse?> {
+  fun handle(e: ExternalApiAuthorisationException): ResponseEntity<ErrorResponse?> {
     log.error(
       "ApiClientAuthorisationException for external client ${e.client} method ${e.method} and url ${e.url}: {}",
       e.message
@@ -102,9 +102,9 @@ class ControllerAdvice {
     return ResponseEntity(ErrorResponse(status = 401, developerMessage = e.message), HttpStatus.UNAUTHORIZED)
   }
 
-  @ExceptionHandler(ApiClientForbiddenException::class)
+  @ExceptionHandler(ExternalApiForbiddenException::class)
   @ResponseStatus(HttpStatus.FORBIDDEN)
-  fun handle(e: ApiClientForbiddenException): ResponseEntity<ErrorResponse?> {
+  fun handle(e: ExternalApiForbiddenException): ResponseEntity<ErrorResponse?> {
     log.error(
       "ApiClientForbiddenException for external client ${e.client} method ${e.method} and url ${e.url}: {}",
       e.message

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AssessmentEpisodeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AssessmentEpisodeEntity.kt
@@ -5,7 +5,6 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType
 import org.hibernate.annotations.Type
 import org.hibernate.annotations.TypeDef
 import org.hibernate.annotations.TypeDefs
-import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.Column
@@ -66,6 +65,4 @@ class AssessmentEpisodeEntity(
   fun close() {
     endDate = LocalDateTime.now()
   }
-
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
@@ -4,40 +4,99 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.ClientResponse
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OASysErrorResponse
 import uk.gov.justice.digital.assessments.services.exceptions.ApiClientAuthorisationException
 import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.ApiClientForbiddenException
 import uk.gov.justice.digital.assessments.services.exceptions.ApiClientInvalidRequestException
 import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
+import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
+import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
 
 fun handle4xxError(
   clientResponse: ClientResponse,
   method: HttpMethod,
   url: String,
-  client: ExternalService,
-  fieldName: String? = ""
+  client: ExternalService
 ): Mono<out Throwable?>? {
   return when (clientResponse.statusCode()) {
     HttpStatus.BAD_REQUEST -> {
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
-        .map { error -> ApiClientInvalidRequestException(error.developerMessage, method, url, client, fieldName) }
+        .map { error -> ApiClientInvalidRequestException(error.developerMessage, method, url, client) }
     }
     HttpStatus.UNAUTHORIZED -> {
-      // log.error("Unauthorised for $method $url with param $fieldName")
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
         .map { error -> ApiClientAuthorisationException(error.developerMessage, method, url, client) }
     }
     HttpStatus.FORBIDDEN -> {
-      // log.error("Unauthorised for $method $url with param $fieldName")
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
         .map { error -> ApiClientForbiddenException(error.developerMessage, method, url, client) }
     }
     HttpStatus.NOT_FOUND -> {
-      // log.error("Not found for $method $url with param $fieldName")
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
         .map { error -> ApiClientEntityNotFoundException(error.developerMessage, method, url, client) }
     }
     else -> handleError(clientResponse, method, url, client)
+  }
+}
+
+fun handle5xxError(
+  message: String,
+  method: HttpMethod,
+  path: String,
+  service: ExternalService
+): Mono<out Throwable?>? {
+  throw ApiClientUnknownException(
+    message,
+    method,
+    path,
+    service
+  )
+}
+
+fun handleOffenderError(
+  crn: String?,
+  user: String?,
+  clientResponse: ClientResponse,
+  method: HttpMethod,
+  url: String
+): Mono<out Throwable?>? {
+  return when {
+    HttpStatus.CONFLICT == clientResponse.statusCode() -> {
+      AssessmentUpdateRestClient.log.error("Unable to create OASys offender. Duplicate OASys offender found for crn: $crn")
+      clientResponse.bodyToMono(OASysErrorResponse::class.java)
+        .map { error -> DuplicateOffenderRecordException(error.developerMessage) }
+    }
+    HttpStatus.FORBIDDEN == clientResponse.statusCode() -> {
+      AssessmentUpdateRestClient.log.error("Unable to create OASys offender. User $user does not have permission to create offender with crn $crn")
+      clientResponse.bodyToMono(OASysErrorResponse::class.java)
+        .map { error -> UserNotAuthorisedException(error.developerMessage) }
+    }
+    else -> handleError(clientResponse, method, url, ExternalService.ASSESSMENTS_API)
+  }
+}
+
+fun handleAssessmentError(
+  offenderPK: Long?,
+  user: String?,
+  assessmentType: AssessmentType,
+  clientResponse: ClientResponse,
+  method: HttpMethod,
+  url: String
+): Mono<out Throwable?>? {
+  return when {
+    HttpStatus.CONFLICT == clientResponse.statusCode() -> {
+      AssessmentUpdateRestClient.log.error("Unable to create OASys assessment. Existing assessment found for offender $offenderPK")
+      clientResponse.bodyToMono(OASysErrorResponse::class.java)
+        .map { error -> DuplicateOffenderRecordException(error.developerMessage) }
+    }
+    HttpStatus.FORBIDDEN == clientResponse.statusCode() -> {
+      AssessmentUpdateRestClient.log.error("Unable to create OASys assessment. User $user does not have permission to create assessment type: $assessmentType for offender with pk $offenderPK")
+      clientResponse.bodyToMono(OASysErrorResponse::class.java)
+        .map { error -> UserNotAuthorisedException(error.developerMessage) }
+    }
+    else -> handleError(clientResponse, method, url, ExternalService.ASSESSMENTS_API)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
@@ -64,14 +64,12 @@ fun handleOffenderError(
 ): Mono<out Throwable?>? {
   return when {
     HttpStatus.CONFLICT == clientResponse.statusCode() -> {
-      AssessmentUpdateRestClient.log.error("Unable to create OASys offender. Duplicate OASys offender found for crn: $crn")
       clientResponse.bodyToMono(OASysErrorResponse::class.java)
-        .map { error -> DuplicateOffenderRecordException(error.developerMessage) }
+        .map { error -> DuplicateOffenderRecordException(error.developerMessage, "Unable to create OASys offender. Duplicate OASys offender found for crn: $crn") }
     }
     HttpStatus.FORBIDDEN == clientResponse.statusCode() -> {
-      AssessmentUpdateRestClient.log.error("Unable to create OASys offender. User $user does not have permission to create offender with crn $crn")
       clientResponse.bodyToMono(OASysErrorResponse::class.java)
-        .map { error -> UserNotAuthorisedException(error.developerMessage) }
+        .map { error -> UserNotAuthorisedException(error.developerMessage, "Unable to create OASys offender. User $user does not have permission to create offender with crn $crn") }
     }
     else -> handleError(clientResponse, method, url, ExternalService.ASSESSMENTS_API)
   }
@@ -87,14 +85,12 @@ fun handleAssessmentError(
 ): Mono<out Throwable?>? {
   return when {
     HttpStatus.CONFLICT == clientResponse.statusCode() -> {
-      AssessmentUpdateRestClient.log.error("Unable to create OASys assessment. Existing assessment found for offender $offenderPK")
       clientResponse.bodyToMono(OASysErrorResponse::class.java)
-        .map { error -> DuplicateOffenderRecordException(error.developerMessage) }
+        .map { error -> DuplicateOffenderRecordException(error.developerMessage, "Unable to create OASys assessment. Existing assessment found for offender $offenderPK") }
     }
     HttpStatus.FORBIDDEN == clientResponse.statusCode() -> {
-      AssessmentUpdateRestClient.log.error("Unable to create OASys assessment. User $user does not have permission to create assessment type: $assessmentType for offender with pk $offenderPK")
       clientResponse.bodyToMono(OASysErrorResponse::class.java)
-        .map { error -> UserNotAuthorisedException(error.developerMessage) }
+        .map { error -> UserNotAuthorisedException(error.developerMessage, "Unable to create OASys assessment. User $user does not have permission to create assessment type: $assessmentType for offender with pk $offenderPK") }
     }
     else -> handleError(clientResponse, method, url, ExternalService.ASSESSMENTS_API)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.assessments.restclient
+
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.ClientResponse
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientAuthorisationException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientForbiddenException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientInvalidRequestException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
+
+fun handle4xxError(
+  clientResponse: ClientResponse,
+  method: HttpMethod,
+  url: String,
+  client: ExternalService,
+  fieldName: String? = ""
+): Mono<out Throwable?>? {
+  return when (clientResponse.statusCode()) {
+    HttpStatus.BAD_REQUEST -> {
+      clientResponse.bodyToMono(ApiErrorResponse::class.java)
+        .map { error -> ApiClientInvalidRequestException(error.developerMessage, method, url, client, fieldName) }
+    }
+    HttpStatus.UNAUTHORIZED -> {
+      // log.error("Unauthorised for $method $url with param $fieldName")
+      clientResponse.bodyToMono(ApiErrorResponse::class.java)
+        .map { error -> ApiClientAuthorisationException(error.developerMessage, method, url, client) }
+    }
+    HttpStatus.FORBIDDEN -> {
+      // log.error("Unauthorised for $method $url with param $fieldName")
+      clientResponse.bodyToMono(ApiErrorResponse::class.java)
+        .map { error -> ApiClientForbiddenException(error.developerMessage, method, url, client) }
+    }
+    HttpStatus.NOT_FOUND -> {
+      // log.error("Not found for $method $url with param $fieldName")
+      clientResponse.bodyToMono(ApiErrorResponse::class.java)
+        .map { error -> ApiClientEntityNotFoundException(error.developerMessage, method, url, client) }
+    }
+    else -> handleError(clientResponse, method, url, client)
+  }
+}
+
+fun handleError(
+  clientResponse: ClientResponse,
+  method: HttpMethod,
+  url: String,
+  client: ExternalService
+): Mono<out Throwable?>? {
+  val httpStatus = clientResponse.statusCode()
+  return clientResponse.bodyToMono(String::class.java).map { error ->
+    ApiClientUnknownException(error, method, url, client)
+  }.or(
+    Mono.error(
+      ApiClientUnknownException(
+        "Unexpected exception with no body and status $httpStatus",
+        method,
+        url,
+        client
+      )
+    )
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorHandler.kt
@@ -6,11 +6,11 @@ import org.springframework.web.reactive.function.client.ClientResponse
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OASysErrorResponse
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientAuthorisationException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientForbiddenException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientInvalidRequestException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiAuthorisationException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiForbiddenException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiInvalidRequestException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknownException
 import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
 import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
 
@@ -23,19 +23,19 @@ fun handle4xxError(
   return when (clientResponse.statusCode()) {
     HttpStatus.BAD_REQUEST -> {
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
-        .map { error -> ApiClientInvalidRequestException(error.developerMessage, method, url, client) }
+        .map { error -> ExternalApiInvalidRequestException(error.developerMessage, method, url, client) }
     }
     HttpStatus.UNAUTHORIZED -> {
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
-        .map { error -> ApiClientAuthorisationException(error.developerMessage, method, url, client) }
+        .map { error -> ExternalApiAuthorisationException(error.developerMessage, method, url, client) }
     }
     HttpStatus.FORBIDDEN -> {
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
-        .map { error -> ApiClientForbiddenException(error.developerMessage, method, url, client) }
+        .map { error -> ExternalApiForbiddenException(error.developerMessage, method, url, client) }
     }
     HttpStatus.NOT_FOUND -> {
       clientResponse.bodyToMono(ApiErrorResponse::class.java)
-        .map { error -> ApiClientEntityNotFoundException(error.developerMessage, method, url, client) }
+        .map { error -> ExternalApiEntityNotFoundException(error.developerMessage, method, url, client) }
     }
     else -> handleError(clientResponse, method, url, client)
   }
@@ -47,7 +47,7 @@ fun handle5xxError(
   path: String,
   service: ExternalService
 ): Mono<out Throwable?>? {
-  throw ApiClientUnknownException(
+  throw ExternalApiUnknownException(
     message,
     method,
     path,
@@ -108,10 +108,10 @@ fun handleError(
 ): Mono<out Throwable?>? {
   val httpStatus = clientResponse.statusCode()
   return clientResponse.bodyToMono(String::class.java).map { error ->
-    ApiClientUnknownException(error, method, url, client)
+    ExternalApiUnknownException(error, method, url, client)
   }.or(
     Mono.error(
-      ApiClientUnknownException(
+      ExternalApiUnknownException(
         "Unexpected exception with no body and status $httpStatus",
         method,
         url,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ApiErrorResponse.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.assessments.restclient
+
+data class ApiErrorResponse(
+  val status: String,
+  val developerMessage: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.assessments.restclient.assessmentapi.OASysAssessme
 import uk.gov.justice.digital.assessments.restclient.assessmentapi.RefElementDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OASysErrorResponse
 import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
 
 @Component
 class AssessmentApiRestClient {
@@ -39,7 +38,7 @@ class AssessmentApiRestClient {
         handleAssessmentError(oasysSetPk, it, HttpMethod.GET, path)
       }
       .onStatus(HttpStatus::is5xxServerError) {
-        throw ApiClientUnknownException(
+        handle5xxError(
           "Failed to retrieve Oasys assessment $oasysSetPk",
           HttpMethod.GET,
           path,
@@ -75,15 +74,13 @@ class AssessmentApiRestClient {
         handle4xxError(
           it,
           HttpMethod.POST,
-          path,
-          ExternalService.ASSESSMENTS_API,
-          fieldName
+          path.plus(" for fieldName $fieldName"),
+          ExternalService.ASSESSMENTS_API
         )
       }
       .onStatus(HttpStatus::is5xxServerError) {
-        throw ApiClientUnknownException(
-          "Failed to retrieve OASys filtered reference data for $fieldName",
-          HttpMethod.POST,
+        handle5xxError(
+          "Failed to retrieve OASys filtered reference data for $fieldName", HttpMethod.POST,
           path,
           ExternalService.ASSESSMENTS_API
         )

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.assessments.restclient.assessmentapi.FilteredRefer
 import uk.gov.justice.digital.assessments.restclient.assessmentapi.OASysAssessmentDto
 import uk.gov.justice.digital.assessments.restclient.assessmentapi.RefElementDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OASysErrorResponse
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
 
 @Component
 class AssessmentApiRestClient {
@@ -100,7 +100,7 @@ class AssessmentApiRestClient {
         AssessmentUpdateRestClient.log.error("Oasys assessment $oasysSetPk not found")
         clientResponse.bodyToMono(OASysErrorResponse::class.java)
           .map { error ->
-            ApiClientEntityNotFoundException(
+            ExternalApiEntityNotFoundException(
               error.developerMessage?.let { error.developerMessage } ?: "",
               method, url, ExternalService.ASSESSMENTS_API
             )

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
@@ -4,23 +4,24 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.ClientResponse
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CompleteAssessmentDto
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentDto
+import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentResponse
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateOffenderDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateOffenderResponseDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OASysErrorResponse
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersDto
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.UpdateAssessmentAnswersResponseDto
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
 import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
-import uk.gov.justice.digital.assessments.services.exceptions.OASysClientException
 import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
-import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentDto
-import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.CreateAssessmentResponse
 
 @Component
 class AssessmentUpdateRestClient {
@@ -39,11 +40,18 @@ class AssessmentUpdateRestClient {
     deliusEvent: Long? = 123456
   ): Long? {
     log.info("Creating offender in OASys for crn: $crn, area: $area, user: $user, delius event: $deliusEvent")
+    val path = "/offenders"
     return webClient
-      .post("/offenders", CreateOffenderDto(crn, area, user, deliusEvent))
+      .post(path, CreateOffenderDto(crn, area, user, deliusEvent))
       .retrieve()
-      .onStatus(HttpStatus::is4xxClientError) { handleOffenderError(crn, user, it) }
-      .onStatus(HttpStatus::is5xxServerError) { throw OASysClientException("Failed to create offender $crn in OASYs") }
+      .onStatus(HttpStatus::is4xxClientError) { handleOffenderError(crn, user, it, HttpMethod.POST, path) }
+      .onStatus(HttpStatus::is5xxServerError) {
+        throw ApiClientUnknownException(
+          "Failed to create offender $crn in OASYs",
+          HttpMethod.POST, path,
+          ExternalService.ASSESSMENTS_UPDATE
+        )
+      }
       .bodyToMono(CreateOffenderResponseDto::class.java)
       .block()?.oasysOffenderId.also {
         log.info("Created offender in OASys for crn: $crn, area: $area, user: $user, delius event: $deliusEvent")
@@ -57,11 +65,28 @@ class AssessmentUpdateRestClient {
     area: String = "WWS",
   ): Long? {
     log.info("Creating Assessment of type $assessmentType in OASys for offender: $offenderPK, area: $area, user: $user")
+    val path = "/assessments"
     return webClient
-      .post("/assessments", CreateAssessmentDto(offenderPK, area, user, assessmentType))
+      .post(path, CreateAssessmentDto(offenderPK, area, user, assessmentType))
       .retrieve()
-      .onStatus(HttpStatus::is4xxClientError) { handleAssessmentError(offenderPK, user, assessmentType, it) }
-      .onStatus(HttpStatus::is5xxServerError) { throw OASysClientException("Failed to create assessment for offender $offenderPK in OASYs") }
+      .onStatus(HttpStatus::is4xxClientError) {
+        handleAssessmentError(
+          offenderPK,
+          user,
+          assessmentType,
+          it,
+          HttpMethod.PUT,
+          path
+        )
+      }
+      .onStatus(HttpStatus::is5xxServerError) {
+        throw ApiClientUnknownException(
+          "Failed to create assessment for offender $offenderPK in OASYs",
+          HttpMethod.POST,
+          path,
+          ExternalService.ASSESSMENTS_UPDATE
+        )
+      }
       .bodyToMono(CreateAssessmentResponse::class.java)
       .block()?.oasysSetPk.also {
         log.info("Created Assessment of type $assessmentType in OASys for offender: $offenderPK, area: $area, user: $user")
@@ -77,11 +102,28 @@ class AssessmentUpdateRestClient {
     area: String = "WWS",
   ): UpdateAssessmentAnswersResponseDto? {
     log.info("Updating answers for Assessment $oasysSetPk in OASys for offender: $offenderPK, area: $area, user: $user, answers: $answers")
+    val path = "/assessments"
     return webClient
-      .put("/assessments", UpdateAssessmentAnswersDto(oasysSetPk, offenderPK, area, user, answers, assessmentType))
+      .put(path, UpdateAssessmentAnswersDto(oasysSetPk, offenderPK, area, user, answers, assessmentType))
       .retrieve()
-      .onStatus(HttpStatus::is4xxClientError) { handleAssessmentError(offenderPK, user, assessmentType, it) }
-      .onStatus(HttpStatus::is5xxServerError) { throw OASysClientException("Failed to update assessment for offender $offenderPK in OASYs") }
+      .onStatus(HttpStatus::is4xxClientError) {
+        handleAssessmentError(
+          offenderPK,
+          user,
+          assessmentType,
+          it,
+          HttpMethod.PUT,
+          path
+        )
+      }
+      .onStatus(HttpStatus::is5xxServerError) {
+        throw ApiClientUnknownException(
+          "Failed to update assessment for offender $offenderPK in OASYs",
+          HttpMethod.PUT,
+          path,
+          ExternalService.ASSESSMENTS_UPDATE
+        )
+      }
       .bodyToMono(UpdateAssessmentAnswersResponseDto::class.java)
       .block().also {
         log.info("Updated answers for Assessment $oasysSetPk in OASys for offender: $offenderPK, area: $area, user: $user")
@@ -97,16 +139,35 @@ class AssessmentUpdateRestClient {
     area: String = "WWS"
   ): UpdateAssessmentAnswersResponseDto? {
     log.info("Completing Assessment $oasysSetPk in OASys for offender: $offenderPK, area: $area, user: $user")
+    val path = "/assessments/complete"
     return webClient
-      .put("/assessments/complete", CompleteAssessmentDto(oasysSetPk, offenderPK, area, user, assessmentType, ignoreWarnings))
+      .put(
+        path,
+        CompleteAssessmentDto(oasysSetPk, offenderPK, area, user, assessmentType, ignoreWarnings)
+      )
       .retrieve()
-      .onStatus(HttpStatus::is4xxClientError) { handleAssessmentError(offenderPK, user, assessmentType, it) }
-      .onStatus(HttpStatus::is5xxServerError) { throw OASysClientException("Failed to complete assessment for offender $offenderPK in OASYs") }
+      .onStatus(HttpStatus::is4xxClientError) {
+        handleAssessmentError(offenderPK, user, assessmentType, it, HttpMethod.PUT, path)
+      }
+      .onStatus(HttpStatus::is5xxServerError) {
+        throw ApiClientUnknownException(
+          "Failed to complete assessment for offender $offenderPK in OASYs",
+          HttpMethod.PUT,
+          path,
+          ExternalService.ASSESSMENTS_UPDATE
+        )
+      }
       .bodyToMono(UpdateAssessmentAnswersResponseDto::class.java)
       .block()
   }
 
-  fun handleOffenderError(crn: String?, user: String?, clientResponse: ClientResponse): Mono<out Throwable?>? {
+  fun handleOffenderError(
+    crn: String?,
+    user: String?,
+    clientResponse: ClientResponse,
+    method: HttpMethod,
+    url: String
+  ): Mono<out Throwable?>? {
     return when {
       HttpStatus.CONFLICT == clientResponse.statusCode() -> {
         log.error("Unable to create OASys offender. Duplicate OASys offender found for crn: $crn")
@@ -118,7 +179,7 @@ class AssessmentUpdateRestClient {
         clientResponse.bodyToMono(OASysErrorResponse::class.java)
           .map { error -> UserNotAuthorisedException(error.developerMessage) }
       }
-      else -> handleError(clientResponse)
+      else -> handleError(clientResponse, method, url)
     }
   }
 
@@ -126,7 +187,9 @@ class AssessmentUpdateRestClient {
     offenderPK: Long?,
     user: String?,
     assessmentType: AssessmentType,
-    clientResponse: ClientResponse
+    clientResponse: ClientResponse,
+    method: HttpMethod,
+    url: String
   ): Mono<out Throwable?>? {
     return when {
       HttpStatus.CONFLICT == clientResponse.statusCode() -> {
@@ -139,15 +202,24 @@ class AssessmentUpdateRestClient {
         clientResponse.bodyToMono(OASysErrorResponse::class.java)
           .map { error -> UserNotAuthorisedException(error.developerMessage) }
       }
-      else -> handleError(clientResponse)
+      else -> handleError(clientResponse, method, url)
     }
   }
 
-  private fun handleError(clientResponse: ClientResponse): Mono<out Throwable?>? {
+  private fun handleError(clientResponse: ClientResponse, method: HttpMethod, url: String): Mono<out Throwable?>? {
     val httpStatus = clientResponse.statusCode()
     log.error("Unexpected exception with status $httpStatus")
     return clientResponse.bodyToMono(String::class.java).map { error ->
-      OASysClientException(error)
-    }.or(Mono.error(OASysClientException("Unexpected exception with no body and status $httpStatus")))
+      ApiClientUnknownException(error, method, url, ExternalService.ASSESSMENTS_UPDATE)
+    }.or(
+      Mono.error(
+        ApiClientUnknownException(
+          "Unexpected exception with no body and status $httpStatus",
+          method,
+          url,
+          ExternalService.ASSESSMENTS_UPDATE
+        )
+      )
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityConvictionDto
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityOffenderDto
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
 
 @Component
 class CommunityApiRestClient {
@@ -32,7 +31,7 @@ class CommunityApiRestClient {
         )
       }
       .onStatus(HttpStatus::is5xxServerError) {
-        throw ApiClientUnknownException(
+        handle5xxError(
           "Failed to retrieve offender details for crn: $crn",
           HttpMethod.GET,
           path,
@@ -58,7 +57,7 @@ class CommunityApiRestClient {
         )
       }
       .onStatus(HttpStatus::is5xxServerError) {
-        throw ApiClientUnknownException(
+        handle5xxError(
           "Failed to retrieve conviction details for crn: $crn, conviction id: $convictionId",
           HttpMethod.GET,
           path,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
@@ -4,9 +4,12 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityConvictionDto
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityOffenderDto
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
 
 @Component
 class CommunityApiRestClient {
@@ -16,18 +19,52 @@ class CommunityApiRestClient {
 
   fun getOffender(crn: String): CommunityOffenderDto? {
     log.info("Client retrieving offender details for crn: $crn")
+    val path = "secure/offenders/crn/$crn/all"
     return webClient
-      .get("secure/offenders/crn/$crn/all")
+      .get(path)
       .retrieve()
+      .onStatus(HttpStatus::is4xxClientError) {
+        handle4xxError(
+          it,
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
+      .onStatus(HttpStatus::is5xxServerError) {
+        throw ApiClientUnknownException(
+          "Failed to retrieve offender details for crn: $crn",
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
       .bodyToMono(CommunityOffenderDto::class.java)
       .block()
   }
 
   fun getConviction(crn: String, convictionId: Long): CommunityConvictionDto? {
     log.info("Client retrieving conviction details for crn: $crn, conviction id: $convictionId")
+    val path = "secure/offenders/crn/$crn/convictions/$convictionId"
     return webClient
-      .get("secure/offenders/crn/$crn/convictions/$convictionId")
+      .get(path)
       .retrieve()
+      .onStatus(HttpStatus::is4xxClientError) {
+        handle4xxError(
+          it,
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
+      .onStatus(HttpStatus::is5xxServerError) {
+        throw ApiClientUnknownException(
+          "Failed to retrieve conviction details for crn: $crn, conviction id: $convictionId",
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
       .bodyToMono(CommunityConvictionDto::class.java)
       .block()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CourtCaseRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CourtCaseRestClient.kt
@@ -9,7 +9,6 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
 
 @Component
 class CourtCaseRestClient {
@@ -48,7 +47,7 @@ class CourtCaseRestClient {
         )
       }
       .onStatus(HttpStatus::is5xxServerError) {
-        throw ApiClientUnknownException(
+        handle5xxError(
           "Fail to retrieve court case for court: $courtCode,  caseNo: $caseNumber",
           HttpMethod.GET,
           path,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ExternalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/ExternalService.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.assessments.restclient
+
+enum class ExternalService {
+  ASSESSMENTS_API, ASSESSMENTS_UPDATE, COMMUNITY_API, PRISONS_API
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/CommunityErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/CommunityErrorResponse.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.assessments.restclient.communityapi
+
+data class CommunityErrorResponse(
+  val status: Int,
+  val userMessage: String? = null,
+  val developerMessage: String? = null
+)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/OffenderService.kt
@@ -27,27 +27,17 @@ class OffenderService(
   }
 
   fun getOffender(crn: String): OffenderDto {
-    try {
-      log.info("Requesting offender details for crn: $crn")
-      val communityOffenderDto = communityApiRestClient.getOffender(crn)
-        ?: throw EntityNotFoundException("No offender found for crn: $crn")
-      return OffenderDto.from(communityOffenderDto)
-    } catch (e: WebClientException) {
-      println(e.message)
-      throw EntityNotFoundException("No offender found for crn: $crn")
-    }
+    log.info("Requesting offender details for crn: $crn")
+    val communityOffenderDto = communityApiRestClient.getOffender(crn)
+      ?: throw EntityNotFoundException("No offender found for crn: $crn")
+    return OffenderDto.from(communityOffenderDto)
   }
 
   fun getOffence(crn: String, convictionId: Long): OffenceDto {
-    try {
-      log.info("Requesting main offence details for crn: $crn, conviction id: $convictionId")
-      val conviction = communityApiRestClient.getConviction(crn, convictionId)
-        ?: throw EntityNotFoundException("No conviction found for crn: $crn, conviction id: $convictionId")
-      return OffenceDto.from(conviction)
-    } catch (e: WebClientException) {
-      println(e.message)
-      throw EntityNotFoundException("No conviction found for crn: $crn, conviction id: $convictionId")
-    }
+    log.info("Requesting main offence details for crn: $crn, conviction id: $convictionId")
+    val conviction = communityApiRestClient.getConviction(crn, convictionId)
+      ?: throw EntityNotFoundException("No conviction found for crn: $crn, conviction id: $convictionId")
+    return OffenceDto.from(conviction)
   }
 
   fun getOffenderAddress(crn: String): Address? {

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/QuestionService.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.assessments.jpa.repositories.OASysMappingRepositor
 import uk.gov.justice.digital.assessments.jpa.repositories.QuestionGroupRepository
 import uk.gov.justice.digital.assessments.jpa.repositories.QuestionSchemaRepository
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
-import java.util.*
+import java.util.UUID
 
 @Service
 class QuestionService(
@@ -138,7 +138,7 @@ class QuestionService(
   }
 
   fun getAllGroupQuestions(groupCode: String): QuestionSchemaEntities {
-    val group = findByGroupCode(groupCode);
+    val group = findByGroupCode(groupCode)
     val allQuestions = mutableListOf<QuestionSchemaEntity>()
 
     group.contents.forEach {
@@ -146,7 +146,8 @@ class QuestionService(
         allQuestions.add(questionSchemaRepository.findByQuestionSchemaUuid(it.contentUuid)!!)
       if (it.contentType == "group")
         allQuestions.addAll(
-          getAllGroupQuestions(it.contentUuid.toString()))
+          getAllGroupQuestions(it.contentUuid.toString())
+        )
     }
 
     return QuestionSchemaEntities(allQuestions)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/OasysAnswers.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
 import uk.gov.justice.digital.assessments.jpa.entities.OASysMappingEntity
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
 import uk.gov.justice.digital.assessments.services.QuestionSchemaEntities
-import java.lang.IllegalStateException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
@@ -10,35 +10,35 @@ class DuplicateOffenderRecordException(msg: String?) : RuntimeException(msg)
 class EntityNotFoundException(msg: String?) : RuntimeException(msg)
 
 // External Services Exceptions
-class ApiClientEntityNotFoundException(
+class ExternalApiEntityNotFoundException(
   msg: String,
   val method: HttpMethod,
   val url: String,
   val client: ExternalService
 ) : RuntimeException(msg)
 
-class ApiClientAuthorisationException(
+class ExternalApiAuthorisationException(
   msg: String,
   val method: HttpMethod,
   val url: String,
   val client: ExternalService
 ) : RuntimeException(msg)
 
-class ApiClientForbiddenException(
+class ExternalApiForbiddenException(
   msg: String,
   val method: HttpMethod,
   val url: String,
   val client: ExternalService
 ) : RuntimeException(msg)
 
-class ApiClientInvalidRequestException(
+class ExternalApiInvalidRequestException(
   msg: String,
   val method: HttpMethod,
   val url: String,
   val client: ExternalService
 ) : RuntimeException(msg)
 
-class ApiClientUnknownException(
+class ExternalApiUnknownException(
   msg: String,
   val method: HttpMethod,
   val url: String,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
@@ -1,9 +1,47 @@
 package uk.gov.justice.digital.assessments.services.exceptions
 
-class EntityNotFoundException(msg: String?) : RuntimeException(msg)
+import org.springframework.http.HttpMethod
+import uk.gov.justice.digital.assessments.restclient.ExternalService
+
+// Internal Service Exceptions
 class UserNotAuthorisedException(msg: String?) : RuntimeException(msg)
-class ReferenceDataAuthorisationException(msg: String?) : RuntimeException(msg)
-class ReferenceDataInvalidRequestException(msg: String?) : RuntimeException(msg)
 class UpdateClosedEpisodeException(msg: String?) : RuntimeException(msg)
 class DuplicateOffenderRecordException(msg: String?) : RuntimeException(msg)
-class OASysClientException(msg: String?) : RuntimeException(msg)
+class EntityNotFoundException(msg: String?) : RuntimeException(msg)
+
+// External Services Exceptions
+class ApiClientEntityNotFoundException(
+  msg: String,
+  val method: HttpMethod,
+  val url: String,
+  val client: ExternalService
+) : RuntimeException(msg)
+
+class ApiClientAuthorisationException(
+  msg: String,
+  val method: HttpMethod,
+  val url: String,
+  val client: ExternalService
+) : RuntimeException(msg)
+
+class ApiClientForbiddenException(
+  msg: String,
+  val method: HttpMethod,
+  val url: String,
+  val client: ExternalService
+) : RuntimeException(msg)
+
+class ApiClientInvalidRequestException(
+  msg: String,
+  val method: HttpMethod,
+  val url: String,
+  val client: ExternalService,
+  val extraParam: String?
+) : RuntimeException(msg)
+
+class ApiClientUnknownException(
+  msg: String,
+  val method: HttpMethod,
+  val url: String,
+  val client: ExternalService
+) : RuntimeException(msg)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
@@ -35,8 +35,7 @@ class ApiClientInvalidRequestException(
   msg: String,
   val method: HttpMethod,
   val url: String,
-  val client: ExternalService,
-  val extraParam: String?
+  val client: ExternalService
 ) : RuntimeException(msg)
 
 class ApiClientUnknownException(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
@@ -4,9 +4,9 @@ import org.springframework.http.HttpMethod
 import uk.gov.justice.digital.assessments.restclient.ExternalService
 
 // Internal Service Exceptions
-class UserNotAuthorisedException(msg: String?) : RuntimeException(msg)
+class UserNotAuthorisedException(msg: String?, val extraInfoMessage: String?) : RuntimeException(msg)
 class UpdateClosedEpisodeException(msg: String?) : RuntimeException(msg)
-class DuplicateOffenderRecordException(msg: String?) : RuntimeException(msg)
+class DuplicateOffenderRecordException(msg: String?, val extraInfoMessage: String?) : RuntimeException(msg)
 class EntityNotFoundException(msg: String?) : RuntimeException(msg)
 
 // External Services Exceptions

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
@@ -25,7 +25,6 @@ import java.util.UUID
 )
 @AutoConfigureWebTestClient(timeout = "50000")
 class AssessmentControllerCreateTest : IntegrationTest() {
-  val episodeId = "current"
 
   @Nested
   @DisplayName("creating court assessments")

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/OffenderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/OffenderControllerTest.kt
@@ -59,7 +59,7 @@ class OffenderControllerTest : IntegrationTest() {
 
   @Test
   fun `returns not found for invalid crn`() {
-    val invalidCrn = "invalid"
+    val invalidCrn = "invalidNotFound"
     webTestClient.get().uri("/offender/crn/$invalidCrn/conviction/$convictionId")
       .headers(setAuthorisation())
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
@@ -4,10 +4,10 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientAuthorisationException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientInvalidRequestException
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiAuthorisationException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiInvalidRequestException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknownException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
 class AssessmentApiTest : IntegrationTest() {
@@ -26,28 +26,28 @@ class AssessmentApiTest : IntegrationTest() {
   fun `retrieve OASys Assessment throws exception when forbidden response received`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(2)
-    }.isInstanceOf(ApiClientEntityNotFoundException::class.java)
+    }.isInstanceOf(ExternalApiEntityNotFoundException::class.java)
   }
 
   @Test
   fun `retrieve OASys Assessment throws exception on server error`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(3)
-    }.isInstanceOf(ApiClientUnknownException::class.java)
+    }.isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
   fun `retrieve OASys Assessment throws exception on unknown client error`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(3)
-    }.isInstanceOf(ApiClientUnknownException::class.java)
+    }.isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
   fun `retrieve OASys Assessment throws exception on unknown client error without body`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(3)
-    }.isInstanceOf(ApiClientUnknownException::class.java)
+    }.isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
@@ -79,7 +79,7 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(ApiClientUnknownException::class.java)
+    }.isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
@@ -95,7 +95,7 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(ApiClientInvalidRequestException::class.java)
+    }.isInstanceOf(ExternalApiInvalidRequestException::class.java)
   }
 
   @Test
@@ -111,7 +111,7 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(ApiClientAuthorisationException::class.java)
+    }.isInstanceOf(ExternalApiAuthorisationException::class.java)
   }
 
   @Test
@@ -127,6 +127,6 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(ApiClientEntityNotFoundException::class.java)
+    }.isInstanceOf(ExternalApiEntityNotFoundException::class.java)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
@@ -4,10 +4,10 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
-import uk.gov.justice.digital.assessments.services.exceptions.OASysClientException
-import uk.gov.justice.digital.assessments.services.exceptions.ReferenceDataAuthorisationException
-import uk.gov.justice.digital.assessments.services.exceptions.ReferenceDataInvalidRequestException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientAuthorisationException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientInvalidRequestException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
 class AssessmentApiTest : IntegrationTest() {
@@ -26,28 +26,28 @@ class AssessmentApiTest : IntegrationTest() {
   fun `retrieve OASys Assessment throws exception when forbidden response received`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(2)
-    }.isInstanceOf(EntityNotFoundException::class.java)
+    }.isInstanceOf(ApiClientEntityNotFoundException::class.java)
   }
 
   @Test
   fun `retrieve OASys Assessment throws exception on server error`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(3)
-    }.isInstanceOf(OASysClientException::class.java)
+    }.isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
   fun `retrieve OASys Assessment throws exception on unknown client error`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(3)
-    }.isInstanceOf(OASysClientException::class.java)
+    }.isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
   fun `retrieve OASys Assessment throws exception on unknown client error without body`() {
     Assertions.assertThatThrownBy {
       assessmentApiRestClient.getOASysAssessment(3)
-    }.isInstanceOf(OASysClientException::class.java)
+    }.isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
@@ -79,7 +79,7 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(OASysClientException::class.java)
+    }.isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
@@ -95,7 +95,7 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(ReferenceDataInvalidRequestException::class.java)
+    }.isInstanceOf(ApiClientInvalidRequestException::class.java)
   }
 
   @Test
@@ -111,7 +111,7 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(ReferenceDataAuthorisationException::class.java)
+    }.isInstanceOf(ApiClientAuthorisationException::class.java)
   }
 
   @Test
@@ -127,6 +127,6 @@ class AssessmentApiTest : IntegrationTest() {
         "assessor_office",
         mapOf("assessor" to "OASYS_ADMIN")
       )
-    }.isInstanceOf(EntityNotFoundException::class.java)
+    }.isInstanceOf(ApiClientEntityNotFoundException::class.java)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.assessments.restclient
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
 class CommunityApiClientTest : IntegrationTest() {
@@ -17,6 +19,13 @@ class CommunityApiClientTest : IntegrationTest() {
     val offenderDto = communityApiRestClient.getOffender(crn)
     assertThat(offenderDto?.offenderId).isEqualTo(101L)
     assertThat(offenderDto?.otherIds?.crn).isEqualTo(crn)
+  }
+
+  @Test
+  fun `get Delius Offender returns not found`() {
+    assertThrows<ApiClientEntityNotFoundException> {
+      communityApiRestClient.getOffender("invalid")
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
@@ -4,7 +4,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiAuthorisationException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiForbiddenException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiInvalidRequestException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknownException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
 class CommunityApiClientTest : IntegrationTest() {
@@ -23,8 +27,36 @@ class CommunityApiClientTest : IntegrationTest() {
 
   @Test
   fun `get Delius Offender returns not found`() {
-    assertThrows<ApiClientEntityNotFoundException> {
-      communityApiRestClient.getOffender("invalid")
+    assertThrows<ExternalApiEntityNotFoundException> {
+      communityApiRestClient.getOffender("invalidNotFound")
+    }
+  }
+
+  @Test
+  fun `get Delius Offender returns bad request`() {
+    assertThrows<ExternalApiInvalidRequestException> {
+      communityApiRestClient.getOffender("invalidBadRequest")
+    }
+  }
+
+  @Test
+  fun `get Delius Offender returns unauthorised`() {
+    assertThrows<ExternalApiAuthorisationException> {
+      communityApiRestClient.getOffender("invalidUnauthorized")
+    }
+  }
+
+  @Test
+  fun `get Delius Offender returns forbidden`() {
+    assertThrows<ExternalApiForbiddenException> {
+      communityApiRestClient.getOffender("invalidForbidden")
+    }
+  }
+
+  @Test
+  fun `get Delius Offender returns unknown exception`() {
+    assertThrows<ExternalApiUnknownException> {
+      communityApiRestClient.getOffender("invalidNotKnow")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CourtCaseClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CourtCaseClientTest.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.assessments.restclient
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
 class CourtCaseClientTest : IntegrationTest() {
@@ -17,5 +19,11 @@ class CourtCaseClientTest : IntegrationTest() {
     val courtCase = courtCaseClient.getCourtCase(courtCode, caseNumber)
 
     assertThat(courtCase?.defendantName).isEqualTo("John Smith")
+  }
+
+  @Test
+  fun `pull court case data returns not found`() {
+    assertThrows<ExternalApiEntityNotFoundException> {
+      courtCaseClient.getCourtCase("notfound", caseNumber)    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
 import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
-import uk.gov.justice.digital.assessments.services.exceptions.OASysClientException
 import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 
@@ -51,19 +51,19 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `create OASys Offender throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createOasysOffender(serverErrorCrn) }
-      .isInstanceOf(OASysClientException::class.java)
+      .isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
   fun `create OASys Offender throws exception on unknown client error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createOasysOffender(clientErrorCrn) }
-      .isInstanceOf(OASysClientException::class.java)
+      .isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
   fun `create OASys Offender throws exception on unknown client error without body`() {
     assertThatThrownBy { assessmentUpdateRestClient.createOasysOffender(clientErrorCrnNoBody) }
-      .isInstanceOf(OASysClientException::class.java)
+      .isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
@@ -87,7 +87,7 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `create OASys Assessment throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createAssessment(serverErrorOffenderPk, assessmentType) }
-      .isInstanceOf(OASysClientException::class.java)
+      .isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
@@ -108,7 +108,7 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `update OASys Assessment throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createAssessment(serverErrorOffenderPk, assessmentType) }
-      .isInstanceOf(OASysClientException::class.java)
+      .isInstanceOf(ApiClientUnknownException::class.java)
   }
 
   @Test
@@ -133,6 +133,6 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `complete OASys Assessment throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.completeAssessment(serverErrorOffenderPk, oasysSetPk, assessmentType) }
-      .isInstanceOf(OASysClientException::class.java)
+      .isInstanceOf(ApiClientUnknownException::class.java)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentType
 import uk.gov.justice.digital.assessments.restclient.assessmentupdateapi.OasysAnswer
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientUnknownException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiUnknownException
 import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
 import uk.gov.justice.digital.assessments.services.exceptions.UserNotAuthorisedException
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
@@ -51,19 +51,19 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `create OASys Offender throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createOasysOffender(serverErrorCrn) }
-      .isInstanceOf(ApiClientUnknownException::class.java)
+      .isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
   fun `create OASys Offender throws exception on unknown client error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createOasysOffender(clientErrorCrn) }
-      .isInstanceOf(ApiClientUnknownException::class.java)
+      .isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
   fun `create OASys Offender throws exception on unknown client error without body`() {
     assertThatThrownBy { assessmentUpdateRestClient.createOasysOffender(clientErrorCrnNoBody) }
-      .isInstanceOf(ApiClientUnknownException::class.java)
+      .isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
@@ -87,7 +87,7 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `create OASys Assessment throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createAssessment(serverErrorOffenderPk, assessmentType) }
-      .isInstanceOf(ApiClientUnknownException::class.java)
+      .isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
@@ -108,7 +108,7 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `update OASys Assessment throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.createAssessment(serverErrorOffenderPk, assessmentType) }
-      .isInstanceOf(ApiClientUnknownException::class.java)
+      .isInstanceOf(ExternalApiUnknownException::class.java)
   }
 
   @Test
@@ -133,6 +133,6 @@ class OASysUpdateClientTest : IntegrationTest() {
   @Test
   fun `complete OASys Assessment throws exception on server error`() {
     assertThatThrownBy { assessmentUpdateRestClient.completeAssessment(serverErrorOffenderPk, oasysSetPk, assessmentType) }
-      .isInstanceOf(ApiClientUnknownException::class.java)
+      .isInstanceOf(ExternalApiUnknownException::class.java)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.assessments.restclient.communityapi.OffenceDetail
 import uk.gov.justice.digital.assessments.restclient.communityapi.OffenderAlias
 import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
 import uk.gov.justice.digital.assessments.restclient.courtcaseapi.DefendantAddress
-import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiEntityNotFoundException
 import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
@@ -97,14 +97,14 @@ class OffenderServiceTest {
 
   @Test
   fun `throws exceptions when no offender exists for CRN`() {
-    every { communityApiRestClient.getOffender(crn) } throws ApiClientEntityNotFoundException(
+    every { communityApiRestClient.getOffender(crn) } throws ExternalApiEntityNotFoundException(
       "",
       HttpMethod.GET,
       "secure/offenders/crn/$crn/all",
       ExternalService.COMMUNITY_API
     )
 
-    assertThrows<ApiClientEntityNotFoundException> { offenderService.getOffenderAndOffence(crn, convictionId) }
+    assertThrows<ExternalApiEntityNotFoundException> { offenderService.getOffenderAndOffence(crn, convictionId) }
     verify(exactly = 1) { communityApiRestClient.getOffender(any()) }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.HttpMethod
 import uk.gov.justice.digital.assessments.jpa.entities.SubjectEntity
 import uk.gov.justice.digital.assessments.jpa.repositories.SubjectRepository
 import uk.gov.justice.digital.assessments.restclient.CommunityApiRestClient
 import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
+import uk.gov.justice.digital.assessments.restclient.ExternalService
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityConvictionDto
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityOffenderDto
 import uk.gov.justice.digital.assessments.restclient.communityapi.IDs
@@ -21,7 +23,7 @@ import uk.gov.justice.digital.assessments.restclient.communityapi.OffenceDetail
 import uk.gov.justice.digital.assessments.restclient.communityapi.OffenderAlias
 import uk.gov.justice.digital.assessments.restclient.courtcaseapi.CourtCase
 import uk.gov.justice.digital.assessments.restclient.courtcaseapi.DefendantAddress
-import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
+import uk.gov.justice.digital.assessments.services.exceptions.ApiClientEntityNotFoundException
 import java.time.LocalDate
 
 @ExtendWith(MockKExtension::class)
@@ -31,7 +33,8 @@ class OffenderServiceTest {
   private val communityApiRestClient: CommunityApiRestClient = mockk()
   private val courtCaseRestClient: CourtCaseRestClient = mockk()
   private val subjectRepository: SubjectRepository = mockk()
-  private val offenderService: OffenderService = OffenderService(communityApiRestClient, subjectRepository, courtCaseRestClient)
+  private val offenderService: OffenderService =
+    OffenderService(communityApiRestClient, subjectRepository, courtCaseRestClient)
 
   private val oasysOffenderPk = 101L
   private val crn = "DX12340A"
@@ -94,9 +97,14 @@ class OffenderServiceTest {
 
   @Test
   fun `throws exceptions when no offender exists for CRN`() {
-    every { communityApiRestClient.getOffender(crn) } returns null
+    every { communityApiRestClient.getOffender(crn) } throws ApiClientEntityNotFoundException(
+      "",
+      HttpMethod.GET,
+      "secure/offenders/crn/$crn/all",
+      ExternalService.COMMUNITY_API
+    )
 
-    assertThrows<EntityNotFoundException> { offenderService.getOffenderAndOffence(crn, convictionId) }
+    assertThrows<ApiClientEntityNotFoundException> { offenderService.getOffenderAndOffence(crn, convictionId) }
     verify(exactly = 1) { communityApiRestClient.getOffender(any()) }
   }
 
@@ -191,6 +199,7 @@ class OffenderServiceTest {
 
     verify(exactly = 1) { communityApiRestClient.getConviction(any(), any()) }
   }
+
   private fun validCourtSubject(): List<SubjectEntity> {
     return listOf(SubjectEntity(sourceId = "courtCode|caseNumber"))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/QuestionServiceTest.kt
@@ -274,7 +274,7 @@ class QuestionServiceTest {
     val tableRef = groupContents[1] as TableQuestionDto
     assertThat(tableRef.tableId).isEqualTo(tableGroup.groupUuid)
     assertThat(tableRef.contents).hasSize(3)
-    val tableQuestionIds = tableRef.contents.subList(0,2).map { (it as GroupQuestionDto).questionId }
+    val tableQuestionIds = tableRef.contents.subList(0, 2).map { (it as GroupQuestionDto).questionId }
     assertThat(tableQuestionIds).contains(tableSubQuestion1Id, tableSubQuestion2Id)
 
     val subGroupRef = tableRef.contents[2] as GroupWithContentsDto

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/AssessmentApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/AssessmentApiMockServer.kt
@@ -163,16 +163,16 @@ class AssessmentApiMockServer : WireMockServer(9004) {
       """.trimIndent()
 
     val getAssessmentNotFoundJson =
-      """{ "developerMessage": "Assessment not found" }""".trimIndent()
+      """{ "status": 404 , "developerMessage": "Assessment not found" }""".trimIndent()
 
     val referenceData400Error =
-      """{ "developerMessage": "Bad Request" }""".trimIndent()
+      """{ "status": 400 , "developerMessage": "Bad Request" }""".trimIndent()
 
     val referenceData401Error =
-      """{ "developerMessage": "Not Authorised" }""".trimIndent()
+      """{ "status": 401 ,"developerMessage": "Not Authorised" }""".trimIndent()
 
     val referenceData404Error =
-      """{ "developerMessage": "Not Found" }""".trimIndent()
+      """{ "status": 404 ,"developerMessage": "Not Found" }""".trimIndent()
 
     val filteredReferenceDataJson =
       """{

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/AssessmentUpdateMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/AssessmentUpdateMockServer.kt
@@ -197,27 +197,6 @@ class AssessmentUpdateMockServer : WireMockServer(9003) {
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
         )
     )
-
-    // stubFor(
-    //   WireMock.put(WireMock.urlEqualTo("/assessments"))
-    //     .withRequestBody(equalToJson("{ \"offenderPk\": 2, \"assessmentType\": \"SHORT_FORM_PSR\" }", true, true))
-    //     .willReturn(
-    //       WireMock.aResponse()
-    //         .withStatus(403)
-    //         .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
-    //         .withBody(createAssessmentForbiddenJson)
-    //     )
-    // )
-    //
-    // stubFor(
-    //   WireMock.put(WireMock.urlEqualTo("/assessments"))
-    //     .withRequestBody(equalToJson("{ \"offenderPk\": 4, \"assessmentType\": \"SHORT_FORM_PSR\" }", true, true))
-    //     .willReturn(
-    //       WireMock.aResponse()
-    //         .withStatus(500)
-    //         .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
-    //     )
-    // )
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
@@ -39,7 +39,17 @@ class CommunityApiMockServer : WireMockServer(9096) {
           WireMock.aResponse()
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
             .withStatus(404)
-            .withBody("{\"status\":\"Error\",\"message\":\"Offender not found\"}")
+            .withBody("{\"status\":\"404\",\"developerMessage\":\"The offender is not found\"}")
+        )
+    )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidBadRequest/all"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(400)
+            .withBody("{\"status\":\"400\",\"developerMessage\":\"Invalid CRN invalidBadRequest\"}")
         )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
@@ -34,7 +34,7 @@ class CommunityApiMockServer : WireMockServer(9096) {
     )
 
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalid/all"))
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidNotFound/all"))
         .willReturn(
           WireMock.aResponse()
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
@@ -50,6 +50,36 @@ class CommunityApiMockServer : WireMockServer(9096) {
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
             .withStatus(400)
             .withBody("{\"status\":\"400\",\"developerMessage\":\"Invalid CRN invalidBadRequest\"}")
+        )
+    )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidUnauthorized/all"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(401)
+            .withBody("{\"status\":\"401\",\"developerMessage\":\"Not authorised\"}")
+        )
+    )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidForbidden/all"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(403)
+            .withBody("{\"status\":\"403\",\"developerMessage\":\"Forbidden\"}")
+        )
+    )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidNotKnow/all"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(422)
+            .withBody("{\"status\":\"422\",\"developerMessage\":\"unprocessable\"}")
         )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CourtCaseMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CourtCaseMockServer.kt
@@ -15,6 +15,16 @@ class CourtCaseMockServer : WireMockServer(9002) {
             .withBody(courtCaseJson)
         )
     )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/court/notfound/case/668911253"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(404)
+            .withBody("{\"status\":\"404\",\"developerMessage\":\"court not found\"}")
+        )
+    )
   }
 
   companion object {


### PR DESCRIPTION
- Added error handling for community and prisons api.
- Refactor the error handling model to group exceptions in 2 categories, internal service exceptions vs external services exceptions. Having that separation of concerns it will be easy to follow errors on the logs and quickly identify if is internal error or an external integration one. in the other hand having common external facing exceptions that we can parametrised for the external services helps us to not pollute the code with plenty of exceptions that at the end have the same meaning.

```
// Internal Service Exceptions
class UserNotAuthorisedException
class UpdateClosedEpisodeException
class DuplicateOffenderRecordException
class EntityNotFoundException

// External Services Exceptions
class ExternalApiEntityNotFoundException
class ExternalApiAuthorisationException
class ExternalApiForbiddenException
class ExternalApiInvalidRequestException
class ExternalApiUnknownException
```
