### PR TITLE
Arn 484: answers json serialisation fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AnswerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AnswerDto.kt
@@ -10,6 +10,11 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import java.lang.IllegalStateException
 
+@JsonSerialize(using = AnswerDtoSerializer::class)
+data class AnswerDto(
+  val items: Collection<String>
+)
+
 object AnswerDtoSerializer : StdSerializer<AnswerDto>(AnswerDto::class.java) {
   override fun serialize(value: AnswerDto?, gen: JsonGenerator?, provider: SerializerProvider?) {
     if (value == null)
@@ -23,25 +28,3 @@ object AnswerDtoSerializer : StdSerializer<AnswerDto>(AnswerDto::class.java) {
   }
 }
 
-object AnswerDtoDeserializer : StdDeserializer<AnswerDto>(AnswerDto::class.java) {
-  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): AnswerDto {
-    val node = ctxt.readTree(p)
-
-    if (node.isTextual) {
-      val item = ctxt.readValue(p, String::class.java)
-      return AnswerDto(listOf(item))
-    }
-    if (node.isArray) {
-      val items = node.elements().asSequence().map { it.asText() }.toList()
-      return AnswerDto(items)
-    }
-
-    throw IllegalStateException("Expected a string or array of strings to deserialise an Answer, but type was ${node.nodeType}")
-  }
-}
-
-@JsonSerialize(using = AnswerDtoSerializer::class)
-@JsonDeserialize(using = AnswerDtoDeserializer::class)
-data class AnswerDto(
-  val items: Collection<String>
-)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AnswersDtoSerializationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AnswersDtoSerializationTest.kt
@@ -42,7 +42,7 @@ class AnswersDtoSerializationTest {
 
     assertJsonIs(
       dto,
-      "{\"answers\":[\"Fruit\"]}"
+      "[\"Fruit\"]"
     )
   }
 
@@ -52,7 +52,7 @@ class AnswersDtoSerializationTest {
 
     assertJsonIs(
       dto,
-      "{\"answers\":[\"Fruit\",\"Vegetables\"]}"
+      "[\"Fruit\",\"Vegetables\"]"
     )
   }
 
@@ -70,7 +70,7 @@ class AnswersDtoSerializationTest {
 
       assertJsonIs(
         dto,
-        "{\"answers\":[[\"Fruit\"],[\"Vegetables\"]]}"
+        "[[\"Fruit\"],[\"Vegetables\"]]"
       )
     }
 
@@ -85,7 +85,7 @@ class AnswersDtoSerializationTest {
 
       assertJsonIs(
         dto,
-        "{\"answers\":[[\"Fruit\"],[\"Potatoes\",\"Carrots\",\"Onions\"]]}"
+        "[[\"Fruit\"],[\"Potatoes\",\"Carrots\",\"Onions\"]]"
       )
     }
 
@@ -100,7 +100,7 @@ class AnswersDtoSerializationTest {
 
       assertJsonIs(
         dto,
-        "{\"answers\":[[\"Potatoes\",\"Carrots\",\"Onions\"],[\"Fruit\"]]}"
+        "[[\"Potatoes\",\"Carrots\",\"Onions\"],[\"Fruit\"]]"
       )
     }
 
@@ -116,7 +116,7 @@ class AnswersDtoSerializationTest {
 
       assertJsonIs(
         dto,
-        "{\"answers\":[[\"Bananas\"],[\"Potatoes\",\"Carrots\",\"Onions\"],[\"Fruit\"]]}"
+        "[[\"Bananas\"],[\"Potatoes\",\"Carrots\",\"Onions\"],[\"Fruit\"]]"
       )
     }
 
@@ -131,7 +131,7 @@ class AnswersDtoSerializationTest {
 
       assertJsonIs(
         dto,
-        "{\"answers\":[[\"Bananas\",\"Apples\"],[\"Potatoes\",\"Carrots\",\"Onions\"]]}"
+        "[[\"Bananas\",\"Apples\"],[\"Potatoes\",\"Carrots\",\"Onions\"]]"
       )
     }
   }


### PR DESCRIPTION
Answers are being serialised as 

```
"0e9ac8f9-7df4-43de-9a7f-756f3fc0e5b3": {
  "answers": [
    "Moira Stuart"
  ]
},
```

But should be more like 

```
"0e9ac8f9-7df4-43de-9a7f-756f3fc0e5b3": 
  [
    "Moira Stuart"
],```
