### PR TITLE
Add initial code for the predictor service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AnswersDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AnswersDto.kt
@@ -28,6 +28,7 @@ data class AnswersDto(
         from(it.value)
       }
     }
+
     private fun from(ae: AnswerEntity): AnswersDto {
       return from(ae.answers)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
@@ -42,7 +42,7 @@ class AssessmentEpisodeDto(
   val assessmentErrors: Collection<String>? = null,
 
   @Schema(description = "Results of predictors")
-  val predictors: MutableCollection<PredictorScoreDto> = mutableListOf(),
+  val predictors: Collection<PredictorScoreDto>,
 ) {
   companion object {
 
@@ -53,6 +53,7 @@ class AssessmentEpisodeDto(
     fun from(
       episode: AssessmentEpisodeEntity,
       errors: AssessmentEpisodeUpdateErrors? = null,
+      predictors: Collection<PredictorScoreDto> = emptyList(),
     ): AssessmentEpisodeDto {
       return AssessmentEpisodeDto(
         episode.episodeId,
@@ -65,7 +66,8 @@ class AssessmentEpisodeDto(
         AnswersDto.from(episode.answers) ?: emptyMap(),
         errors?.errors,
         errors?.pageErrors,
-        errors?.assessmentErrors
+        errors?.assessmentErrors,
+        predictors,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
@@ -35,8 +35,14 @@ class AssessmentEpisodeDto(
   @Schema(description = "Validation errors on this episode, indexed by question UUID")
   val errors: Map<UUID, Collection<String>>? = null,
 
+  @Schema(description = "Validation level errors")
   val pageErrors: Collection<String>? = null,
-  val assessmentErrors: Collection<String>? = null
+
+  @Schema(description = "OASys assessment errors")
+  val assessmentErrors: Collection<String>? = null,
+
+  @Schema(description = "Results of predictors")
+  val predictors: MutableCollection<PredictorScoreDto> = mutableListOf(),
 ) {
   companion object {
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoreDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoreDto.kt
@@ -3,16 +3,28 @@ package uk.gov.justice.digital.assessments.api
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.assessments.jpa.entities.PredictorType
 
+enum class PredictorResultStatus {
+  DETERMINED,
+  UNDETERMINED,
+  FAILED,
+}
+
 class PredictorScoreDto(
   @Schema(description = "Predictor type", example = "RSR")
   val predictor: PredictorType,
+
+  @Schema(description = "Predictor result status", example = "COMPLETE")
+  val predictorResultStatus: PredictorResultStatus = PredictorResultStatus.DETERMINED,
 
   @Schema(description = "Predictor score", example = "1")
   val score: Number? = null,
 ) {
   companion object {
-    fun conditionsNotMet(predictor: PredictorType): PredictorScoreDto {
-      return PredictorScoreDto(predictor)
+    fun incomplete(predictor: PredictorType): PredictorScoreDto {
+      return PredictorScoreDto(
+        predictor = predictor,
+        predictorResultStatus = PredictorResultStatus.UNDETERMINED
+      )
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoreDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoreDto.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.assessments.api
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.assessments.jpa.entities.PredictorType
+
+class PredictorScoreDto(
+  @Schema(description = "Predictor type", example = "RSR")
+  val predictor: PredictorType,
+
+  @Schema(description = "Predictor score", example = "1")
+  val score: Number? = null,
+) {
+  companion object {
+    fun conditionsNotMet(predictor: PredictorType): PredictorScoreDto {
+      return PredictorScoreDto(predictor)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoreDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoreDto.kt
@@ -11,10 +11,10 @@ enum class PredictorResultStatus {
 
 class PredictorScoreDto(
   @Schema(description = "Predictor type", example = "RSR")
-  val predictor: PredictorType,
+  val type: PredictorType,
 
   @Schema(description = "Predictor result status", example = "COMPLETE")
-  val predictorResultStatus: PredictorResultStatus = PredictorResultStatus.DETERMINED,
+  val status: PredictorResultStatus = PredictorResultStatus.DETERMINED,
 
   @Schema(description = "Predictor score", example = "1")
   val score: Number? = null,
@@ -22,8 +22,8 @@ class PredictorScoreDto(
   companion object {
     fun incomplete(predictor: PredictorType): PredictorScoreDto {
       return PredictorScoreDto(
-        predictor = predictor,
-        predictorResultStatus = PredictorResultStatus.UNDETERMINED
+        type = predictor,
+        status = PredictorResultStatus.UNDETERMINED
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AssessmentSchemaEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AssessmentSchemaEntity.kt
@@ -42,5 +42,5 @@ class AssessmentSchemaEntity(
 
   @OneToMany
   @JoinColumn(name = "assessment_schema_code", referencedColumnName = "assessment_schema_code")
-  val predictorFields: Collection<Predictor> = emptyList(),
+  val predictors: Collection<Predictor> = emptyList(),
 ) : Serializable

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/Predictor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/Predictor.kt
@@ -26,9 +26,9 @@ class Predictor(
 
   @Column(name = "predictor_type")
   @Enumerated(EnumType.STRING)
-  val predictorType: PredictorType,
+  val type: PredictorType,
 
   @OneToMany
   @JoinColumn(name = "predictor_type", referencedColumnName = "predictor_type")
-  val predictorFields: Collection<PredictorFieldMapping> = emptyList(),
+  val fields: Collection<PredictorFieldMapping> = emptyList(),
 ) : Serializable

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentSchemaService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentSchemaService.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.assessments.api.GroupSectionsDto
 import uk.gov.justice.digital.assessments.api.GroupWithContentsDto
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode
 import uk.gov.justice.digital.assessments.jpa.entities.OasysAssessmentType
+import uk.gov.justice.digital.assessments.jpa.entities.Predictor
 import uk.gov.justice.digital.assessments.jpa.repositories.AssessmentSchemaRepository
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.OasysAssessmentTypeMappingMissing
@@ -14,6 +15,10 @@ class AssessmentSchemaService(
   private val assessmentSchemaRepository: AssessmentSchemaRepository,
   private val questionService: QuestionService
 ) {
+
+  fun getPredictorsForAssessment(assessmentSchemaCode: AssessmentSchemaCode?) : List<Predictor> {
+    return assessmentSchemaRepository.findByAssessmentSchemaCode(assessmentSchemaCode!!)?.predictors.orEmpty().toList()
+  }
 
   fun getAssessmentSchema(assessmentSchemaCode: AssessmentSchemaCode?): GroupWithContentsDto {
     val assessmentSchemaGroupUuid =

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
@@ -68,15 +68,11 @@ class AssessmentUpdateService(
     assessmentRepository.save(episode.assessment)
     log.info("Saved episode ${episode.episodeUuid} for assessment ${episode.assessment?.assessmentUuid}")
 
-    val updatedEpisode = AssessmentEpisodeDto.from(episode, oasysResult)
-
     val predictorResults = episode.assessmentSchemaCode?.let {
-      predictorService.getPredictorResults(it, updatedEpisode.answers)
+      predictorService.getPredictorResults(it, episode)
     }
 
-    updatedEpisode.predictors.addAll(predictorResults.orEmpty())
-
-    return updatedEpisode
+    return AssessmentEpisodeDto.from(episode, oasysResult, predictorResults.orEmpty())
   }
 
   fun AssessmentEpisodeEntity.updateEpisodeAnswers(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.jpa.entities.Answer
 import uk.gov.justice.digital.assessments.jpa.entities.AnswerEntity
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentEpisodeEntity
-import uk.gov.justice.digital.assessments.jpa.entities.PredictorFieldMapping
 import uk.gov.justice.digital.assessments.jpa.repositories.AssessmentRepository
 import uk.gov.justice.digital.assessments.jpa.repositories.EpisodeRepository
 import uk.gov.justice.digital.assessments.restclient.AssessmentUpdateRestClient
@@ -74,6 +73,8 @@ class AssessmentUpdateService(
     val predictorResults = episode.assessmentSchemaCode?.let {
       predictorService.getPredictorResults(it, updatedEpisode.answers)
     }
+
+    updatedEpisode.predictors.addAll(predictorResults.orEmpty())
 
     // Add to AssessmentEpisodeDTO or create wrapping DTO?
     return updatedEpisode

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
@@ -76,7 +76,6 @@ class AssessmentUpdateService(
 
     updatedEpisode.predictors.addAll(predictorResults.orEmpty())
 
-    // Add to AssessmentEpisodeDTO or create wrapping DTO?
     return updatedEpisode
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.assessments.services
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.assessments.api.AnswersDto
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode
+import uk.gov.justice.digital.assessments.jpa.entities.PredictorFieldMapping
+import java.util.UUID
+
+@Service
+class PredictorService(
+  private val assessmentSchemaService: AssessmentSchemaService,
+) {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getPredictorResults(
+    assessmentSchemaCode: AssessmentSchemaCode,
+    episodeAnswers: Map<UUID, AnswersDto>,
+  ): List<Int> {
+    val predictors = assessmentSchemaService.getPredictorsForAssessment(assessmentSchemaCode)
+    log.info("Found ${predictors.size} predictors for assessment type $assessmentSchemaCode")
+
+    return predictors.map {
+      if (hasRequiredFieldsForScore(it.predictorFields.toList(), episodeAnswers)) {
+        // Request predictor score and return PredictorResult
+        1
+      } else {
+        // Return PredictorResult as N/A
+        0
+      }
+    }
+  }
+
+  private fun hasRequiredFieldsForScore(
+    predictorFields: List<PredictorFieldMapping>,
+    answers: Map<UUID, AnswersDto>
+  ): Boolean {
+    val numberOfAnsweredPredictorFields = predictorFields.fold(0) {
+      total, field -> if (answers[field.questionSchema.questionSchemaUuid] != null) total + 1 else total
+    }
+
+    return numberOfAnsweredPredictorFields == predictorFields.size
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -3,11 +3,11 @@ package uk.gov.justice.digital.assessments.services
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.assessments.api.AnswerDto
 import uk.gov.justice.digital.assessments.api.AnswersDto
 import uk.gov.justice.digital.assessments.api.PredictorScoreDto
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode
 import uk.gov.justice.digital.assessments.jpa.entities.PredictorFieldMapping
+import uk.gov.justice.digital.assessments.jpa.entities.PredictorType
 import java.util.UUID
 
 @Service
@@ -30,20 +30,30 @@ class PredictorService(
       val predictorFields = predictor.fields.toList()
       val extractedAnswers = extractAnswers(predictorFields, episodeAnswers)
       if (predictorFields.isNotEmpty() && predictorFields.size == extractedAnswers.size)
-        PredictorScoreDto(predictor.type, 1234) else PredictorScoreDto.conditionsNotMet(predictor.type)
+        fetchResults(predictor.type, extractedAnswers) else PredictorScoreDto.incomplete(predictor.type)
     }
   }
 
   private fun extractAnswers(
     predictorFields: List<PredictorFieldMapping>,
     answers: Map<UUID, AnswersDto>
-  ): Map<String, Collection<AnswerDto>> {
+  ): Map<String, AnswersDto> {
     return predictorFields
       .associate { predictorField ->
         val questionUuid = predictorField.questionSchema.questionSchemaUuid
         val questionAnswer = answers[questionUuid]
-        (predictorField.predictorFieldName to questionAnswer?.answers.orEmpty())
+        (predictorField.predictorFieldName to questionAnswer)
       }
-      .filterValues { extractedAnswer -> extractedAnswer.isNotEmpty() }
+      .filterValues { it != null  }
+      .mapValues { it.value as AnswersDto }
+      // ☝️ The compiler needs help here to infer the returned type 🤔
+  }
+
+  private fun fetchResults(
+    predictorType: PredictorType,
+    answers: Map<String, AnswersDto>,
+  ) : PredictorScoreDto {
+    log.info("Stubbed call to get Predictor Score")
+    return PredictorScoreDto(predictorType, 1234)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.assessments.services
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.assessments.api.AnswerDto
 import uk.gov.justice.digital.assessments.api.AnswersDto
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode
 import uk.gov.justice.digital.assessments.jpa.entities.PredictorFieldMapping
@@ -24,7 +25,9 @@ class PredictorService(
     log.info("Found ${predictors.size} predictors for assessment type $assessmentSchemaCode")
 
     return predictors.map {
-      if (hasRequiredFieldsForScore(it.predictorFields.toList(), episodeAnswers)) {
+      val predictorFields = it.predictorFields.toList()
+      val extractedAnswers = extractAnswers(it.predictorFields.toList(), episodeAnswers)
+      if (predictorFields.isNotEmpty() && predictorFields.size == extractedAnswers.size) {
         // Request predictor score and return PredictorResult
         1
       } else {
@@ -34,14 +37,16 @@ class PredictorService(
     }
   }
 
-  private fun hasRequiredFieldsForScore(
+  private fun extractAnswers(
     predictorFields: List<PredictorFieldMapping>,
     answers: Map<UUID, AnswersDto>
-  ): Boolean {
-    val numberOfAnsweredPredictorFields = predictorFields.fold(0) {
-      total, field -> if (answers[field.questionSchema.questionSchemaUuid] != null) total + 1 else total
-    }
-
-    return predictorFields.isNotEmpty() && numberOfAnsweredPredictorFields == predictorFields.size
+  ): Map<UUID, Collection<AnswerDto>> {
+    return predictorFields
+      .map { it.questionSchema.questionSchemaUuid }
+      .associate { questionSchemaUuid ->
+        val questionAnswer = answers[questionSchemaUuid]
+        (questionSchemaUuid to questionAnswer?.answers.orEmpty())
+      }
+      .filterValues { it.isNotEmpty() }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -42,6 +42,6 @@ class PredictorService(
       total, field -> if (answers[field.questionSchema.questionSchemaUuid] != null) total + 1 else total
     }
 
-    return numberOfAnsweredPredictorFields == predictorFields.size
+    return predictorFields.isNotEmpty() && numberOfAnsweredPredictorFields == predictorFields.size
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -54,6 +54,9 @@ class PredictorService(
     answers: Map<String, AnswersDto>,
   ) : PredictorScoreDto {
     log.info("Stubbed call to get Predictor Score")
-    return PredictorScoreDto(predictorType, 1234)
+    return PredictorScoreDto(
+      predictor = predictorType,
+      score = 1234
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -46,7 +46,7 @@ class PredictorService(
       }
       .filterValues { it != null  }
       .mapValues { it.value as AnswersDto }
-      // ☝️ The compiler needs help here to infer the returned type 🤔
+      // The compiler needs help here to infer the returned type 🤔
   }
 
   private fun fetchResults(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -37,12 +37,12 @@ class PredictorService(
   private fun extractAnswers(
     predictorFields: List<PredictorFieldMapping>,
     answers: Map<UUID, AnswersDto>
-  ): Map<UUID, Collection<AnswerDto>> {
+  ): Map<String, Collection<AnswerDto>> {
     return predictorFields
-      .map { predictorField -> predictorField.questionSchema.questionSchemaUuid }
-      .associate { questionSchemaUuid ->
-        val questionAnswer = answers[questionSchemaUuid]
-        (questionSchemaUuid to questionAnswer?.answers.orEmpty())
+      .associate { predictorField ->
+        val questionUuid = predictorField.questionSchema.questionSchemaUuid
+        val questionAnswer = answers[questionUuid]
+        (predictorField.predictorFieldName to questionAnswer?.answers.orEmpty())
       }
       .filterValues { extractedAnswer -> extractedAnswer.isNotEmpty() }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -55,7 +55,7 @@ class PredictorService(
   ) : PredictorScoreDto {
     log.info("Stubbed call to get Predictor Score")
     return PredictorScoreDto(
-      predictor = predictorType,
+      type = predictorType,
       score = 1234
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
@@ -38,6 +38,7 @@ class AssessmentUpdateServiceCompleteTest {
   private val episodeService: EpisodeService = mockk()
   private val offenderService: OffenderService = mockk()
   private val assessmentSchemaService: AssessmentSchemaService = mockk()
+  private val predictorService: PredictorService = mockk()
 
   private val assessmentService = AssessmentService(
     assessmentRepository,
@@ -47,7 +48,7 @@ class AssessmentUpdateServiceCompleteTest {
     courtCaseRestClient,
     assessmentUpdateRestClient,
     offenderService,
-    assessmentSchemaService
+    assessmentSchemaService,
   )
 
   private val assessmentUpdateService = AssessmentUpdateService(
@@ -56,7 +57,8 @@ class AssessmentUpdateServiceCompleteTest {
     questionService,
     assessmentUpdateRestClient,
     assessmentService,
-    assessmentSchemaService
+    assessmentSchemaService,
+    predictorService,
   )
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceOASysTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceOASysTest.kt
@@ -44,6 +44,7 @@ class AssessmentUpdateServiceOASysTest {
   private val assessmentUpdateRestClient: AssessmentUpdateRestClient = mockk()
   private val assessmentService: AssessmentService = mockk()
   private val assessmentSchemaService: AssessmentSchemaService = mockk()
+  private val predictorService: PredictorService = mockk()
 
   private val assessmentsUpdateService = AssessmentUpdateService(
     assessmentRepository,
@@ -51,7 +52,8 @@ class AssessmentUpdateServiceOASysTest {
     questionService,
     assessmentUpdateRestClient,
     assessmentService,
-    assessmentSchemaService
+    assessmentSchemaService,
+    predictorService,
   )
 
   private val assessmentUuid = UUID.randomUUID()
@@ -356,6 +358,7 @@ class AssessmentUpdateServiceOASysTest {
       )
     )
     every { assessmentUpdateRestClient.updateAssessment(any(), any(), any(), any()) } returns oasysError
+    every { predictorService.getPredictorResults(any(), any()) } returns emptyList()
     // Christ, what a lot of set up
 
     // Apply the update
@@ -397,6 +400,7 @@ class AssessmentUpdateServiceOASysTest {
     } returns UpdateAssessmentAnswersResponseDto()
     every { questionService.getAllQuestions() } returns setupQuestionCodes()
     every { assessmentRepository.save(any()) } returns mockk()
+    every { predictorService.getPredictorResults(any(), any()) } returns emptyList()
 
     val update = UpdateAssessmentEpisodeDto(answers = mapOf(question1Uuid to listOf("Updated")))
     val updatedEpisode = assessmentsUpdateService.updateEpisode(assessmentUuid, episodeUuid, update)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
@@ -34,6 +34,7 @@ class AssessmentUpdateServiceTest {
   private val episodeService: EpisodeService = mockk()
   private val offenderService: OffenderService = mockk()
   private val assessmentSchemaService: AssessmentSchemaService = mockk()
+  private val predictorService: PredictorService = mockk()
 
   private val assessmentService = AssessmentService(
     assessmentRepository,
@@ -43,7 +44,7 @@ class AssessmentUpdateServiceTest {
     courtCaseRestClient,
     assessmentUpdateRestClient,
     offenderService,
-    assessmentSchemaService
+    assessmentSchemaService,
   )
   private val assessmentUpdateService = AssessmentUpdateService(
     assessmentRepository,
@@ -51,7 +52,8 @@ class AssessmentUpdateServiceTest {
     questionService,
     assessmentUpdateRestClient,
     assessmentService,
-    assessmentSchemaService
+    assessmentSchemaService,
+    predictorService,
   )
 
   private val assessmentUuid = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.assessments.services
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.assessments.api.AnswerDto
+import uk.gov.justice.digital.assessments.api.AnswersDto
+import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode.RSR_ONLY
+import uk.gov.justice.digital.assessments.jpa.entities.Predictor
+import uk.gov.justice.digital.assessments.jpa.entities.PredictorFieldMapping
+import uk.gov.justice.digital.assessments.jpa.entities.PredictorType.RSR
+import uk.gov.justice.digital.assessments.jpa.entities.QuestionSchemaEntity
+import java.util.*
+
+class PredictorServiceTest {
+  private val assessmentSchemaService: AssessmentSchemaService = mockk()
+
+  private val predictorService = PredictorService(assessmentSchemaService)
+
+  private val testQuestion = QuestionSchemaEntity(
+    questionSchemaId = 1,
+    questionSchemaUuid = UUID.randomUUID(),
+  )
+
+  private val predictors = listOf(Predictor(
+    1,
+    RSR_ONLY,
+    RSR,
+    listOf(
+      PredictorFieldMapping(
+        1,
+        UUID.randomUUID(),
+        testQuestion,
+        RSR,
+        "predictor_field_name"
+      )
+    )
+  ))
+
+  private val answers = mapOf(
+    testQuestion.questionSchemaUuid to AnswersDto(
+      listOf(AnswerDto(items = listOf("TEST_VALUE")))
+    )
+  )
+
+  @Nested
+  @DisplayName("get predictor results")
+  inner class GetPredictorResults {
+    @Test
+    fun `returns predictor scores for the assessment code`() {
+      every { assessmentSchemaService.getPredictorsForAssessment(RSR_ONLY) } returns predictors
+
+      val results = predictorService.getPredictorResults(RSR_ONLY, answers)
+
+      assertThat(results).hasSize(1)
+      assertThat(results.first().predictor).isEqualTo(RSR)
+      assertThat(results.first().score).isEqualTo(1234)
+    }
+
+    @Test
+    fun `does not return a score when predictor conditions are not met`() {
+      every { assessmentSchemaService.getPredictorsForAssessment(RSR_ONLY) } returns predictors
+
+      val results = predictorService.getPredictorResults(RSR_ONLY, emptyMap())
+
+      assertThat(results).hasSize(1)
+      assertThat(results.first().predictor).isEqualTo(RSR)
+      assertThat(results.first().score).isNull()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
@@ -58,8 +58,8 @@ class PredictorServiceTest {
       val results = predictorService.getPredictorResults(RSR_ONLY, answers)
 
       assertThat(results).hasSize(1)
-      assertThat(results.first().predictor).isEqualTo(RSR)
-      assertThat(results.first().predictorResultStatus).isEqualTo(DETERMINED)
+      assertThat(results.first().type).isEqualTo(RSR)
+      assertThat(results.first().status).isEqualTo(DETERMINED)
       assertThat(results.first().score).isEqualTo(1234)
     }
 
@@ -70,8 +70,8 @@ class PredictorServiceTest {
       val results = predictorService.getPredictorResults(RSR_ONLY, emptyMap())
 
       assertThat(results).hasSize(1)
-      assertThat(results.first().predictor).isEqualTo(RSR)
-      assertThat(results.first().predictorResultStatus).isEqualTo(UNDETERMINED)
+      assertThat(results.first().type).isEqualTo(RSR)
+      assertThat(results.first().status).isEqualTo(UNDETERMINED)
       assertThat(results.first().score).isNull()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.assessments.api.AnswerDto
 import uk.gov.justice.digital.assessments.api.AnswersDto
+import uk.gov.justice.digital.assessments.api.PredictorResultStatus.DETERMINED
+import uk.gov.justice.digital.assessments.api.PredictorResultStatus.UNDETERMINED
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode.RSR_ONLY
 import uk.gov.justice.digital.assessments.jpa.entities.Predictor
 import uk.gov.justice.digital.assessments.jpa.entities.PredictorFieldMapping
@@ -57,6 +59,7 @@ class PredictorServiceTest {
 
       assertThat(results).hasSize(1)
       assertThat(results.first().predictor).isEqualTo(RSR)
+      assertThat(results.first().predictorResultStatus).isEqualTo(DETERMINED)
       assertThat(results.first().score).isEqualTo(1234)
     }
 
@@ -68,6 +71,7 @@ class PredictorServiceTest {
 
       assertThat(results).hasSize(1)
       assertThat(results.first().predictor).isEqualTo(RSR)
+      assertThat(results.first().predictorResultStatus).isEqualTo(UNDETERMINED)
       assertThat(results.first().score).isNull()
     }
   }


### PR DESCRIPTION
## Context

This PR add's the initial code for the service layer logic to determine if the available answers on an assessment meet the conditions of it's associated predictors

## Responses

The predictors are returned alongside the updated episode
```json
{
    "episodeId": 2,
    "episodeUuid": "90f2b674-ae1c-488d-8b85-0251708ef6b6",
    "assessmentUuid": "6f3f2c4a-38ac-49ce-b790-70bc170fe553",
    "reasonForChange": "new episode",
    "created": "2019-11-14T08:11:53.177108",
    "answers": {
        "63099aab-f852-4dd9-9179-16ee2218d0c6": [
            "34"
        ]
    },
    "predictors": [
        {
            "type": "RSR",
            "status": "DETERMINED",
            "score": 1234

        }
    ]
}
```

## Request

The request to the ARN API is currently stubbed pending implementation - the request will look something like this and uses the `AnswersDto` to support different types and answers for multiple choice questions 

```json
{
    "type": "RSR",
    "answers": {
        "age_first_sanction": ["34"]
    }
}
```