### PR TITLE
Arn 528 complete and update assessment pust to oasys

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
@@ -124,6 +124,30 @@ class AssessmentUpdateRestClient {
       }
   }
 
+  /*
+  * Use this method to conditionally Push Updates to Assessments in Oasys depending on the Assessment Schema Code
+  * DO NOT CHANGE THIS METHOD SIGNATURE as it does work with PushToOasysAspect to decide for which assessments
+  * we push updated data into Oasys
+  * */
+  fun pushUpdateToOasys(
+    offenderPK: Long,
+    oasysSetPk: Long,
+    assessmentSchemaCode: AssessmentSchemaCode?,
+    answers: Set<OasysAnswer>,
+  ): UpdateAssessmentAnswersResponseDto? {
+    val oasysAssessmentType = assessmentSchemaService.toOasysAssessmentType(assessmentSchemaCode)
+    return updateAssessment(
+      offenderPK,
+      oasysAssessmentType,
+      oasysSetPk,
+      answers
+    )
+  }
+
+  /*
+  * Use this method only if you want to force Updating Assessment in Oasys
+  * Note that the assessment should have been created previously in Oasys.
+  * */
   @Authorized(roleChecks = [Roles.ASSESSMENT_EDIT])
   fun updateAssessment(
     offenderPK: Long,
@@ -162,6 +186,30 @@ class AssessmentUpdateRestClient {
       }
   }
 
+  /*
+ * Use this method to conditionally Push Completing an Assessments to Oasys depending on the Assessment Schema Code
+ * DO NOT CHANGE THIS METHOD SIGNATURE as it does work with PushToOasysAspect to decide for which assessments
+ * we push a completed status and data into Oasys
+ * */
+  fun pushCompleteToOasys(
+    offenderPK: Long,
+    oasysSetPk: Long,
+    assessmentSchemaCode: AssessmentSchemaCode?,
+    ignoreWarnings: Boolean = true
+  ): UpdateAssessmentAnswersResponseDto? {
+    val oasysAssessmentType = assessmentSchemaService.toOasysAssessmentType(assessmentSchemaCode)
+    return completeAssessment(
+      offenderPK,
+      oasysAssessmentType,
+      oasysSetPk,
+      ignoreWarnings
+    )
+  }
+
+  /*
+  * Use this method only if you want to force Completing an Assessment in Oasys.
+  * Note that the assessment should have been created previously in Oasys.
+  * */
   @Authorized(roleChecks = [Roles.ASSESSMENT_EDIT])
   fun completeAssessment(
     offenderPK: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentUpdateRestClient.kt
@@ -130,16 +130,16 @@ class AssessmentUpdateRestClient {
   * we push updated data into Oasys
   * */
   fun pushUpdateToOasys(
-    offenderPK: Long,
-    oasysSetPk: Long,
+    offenderPK: Long? = null,
+    oasysSetPk: Long? = null,
     assessmentSchemaCode: AssessmentSchemaCode?,
-    answers: Set<OasysAnswer>,
+    answers: Set<OasysAnswer> = emptySet(),
   ): UpdateAssessmentAnswersResponseDto? {
     val oasysAssessmentType = assessmentSchemaService.toOasysAssessmentType(assessmentSchemaCode)
     return updateAssessment(
-      offenderPK,
+      offenderPK!!,
       oasysAssessmentType,
-      oasysSetPk,
+      oasysSetPk!!,
       answers
     )
   }
@@ -192,16 +192,16 @@ class AssessmentUpdateRestClient {
  * we push a completed status and data into Oasys
  * */
   fun pushCompleteToOasys(
-    offenderPK: Long,
-    oasysSetPk: Long,
+    offenderPK: Long? = null,
+    oasysSetPk: Long? = null,
     assessmentSchemaCode: AssessmentSchemaCode?,
     ignoreWarnings: Boolean = true
   ): UpdateAssessmentAnswersResponseDto? {
     val oasysAssessmentType = assessmentSchemaService.toOasysAssessmentType(assessmentSchemaCode)
     return completeAssessment(
-      offenderPK,
+      offenderPK!!,
       oasysAssessmentType,
-      oasysSetPk,
+      oasysSetPk!!,
       ignoreWarnings
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -35,8 +35,7 @@ class AssessmentService(
   private val episodeService: EpisodeService,
   private val courtCaseClient: CourtCaseRestClient,
   private val assessmentUpdateRestClient: AssessmentUpdateRestClient,
-  private val offenderService: OffenderService,
-  private val assessmentSchemaService: AssessmentSchemaService
+  private val offenderService: OffenderService
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
@@ -27,9 +27,8 @@ class AssessmentUpdateService(
   private val questionService: QuestionService,
   private val assessmentUpdateRestClient: AssessmentUpdateRestClient,
   private val assessmentService: AssessmentService,
-  private val assessmentSchemaService: AssessmentSchemaService,
   private val predictorService: PredictorService,
-) {
+  ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
@@ -113,10 +112,10 @@ class AssessmentUpdateService(
       }
     )
 
-    val oasysUpdateResult = assessmentUpdateRestClient.updateAssessment(
+    val oasysUpdateResult = assessmentUpdateRestClient.pushUpdateToOasys(
       offenderPk,
-      assessmentSchemaService.toOasysAssessmentType(episode.assessmentSchemaCode),
       episode.oasysSetPk!!,
+      episode.assessmentSchemaCode,
       oasysAnswers
     )
     log.info("Updated OASys assessment oasysSet ${episode.oasysSetPk} ${if (oasysUpdateResult?.validationErrorDtos?.isNotEmpty() == true) "with errors" else "successfully"}")
@@ -367,11 +366,8 @@ class AssessmentUpdateService(
     offenderPk: Long,
     episode: AssessmentEpisodeEntity,
   ): AssessmentEpisodeUpdateErrors? {
-    val oasysUpdateResult = assessmentUpdateRestClient.completeAssessment(
-      offenderPk,
-      assessmentSchemaService.toOasysAssessmentType(episode.assessmentSchemaCode),
-      episode.oasysSetPk!!
-    )
+    val oasysUpdateResult =
+      assessmentUpdateRestClient.pushCompleteToOasys(offenderPk, episode.oasysSetPk!!, episode.assessmentSchemaCode)
     if (oasysUpdateResult?.validationErrorDtos?.isNotEmpty() == true) {
       log.info("Could not complete OASys assessment oasysSet ${episode.oasysSetPk} with errors")
     } else log.info("Completed OASys assessment oasysSet $episode.oasysSetPk successfully")

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
@@ -120,6 +120,20 @@ class OASysUpdateClientTest : IntegrationTest() {
   }
 
   @Test
+  fun `Trying to push to OASys Assessment update that should not be pushed into Oasys returns null`() {
+    val updateAssessmentResponse =
+      assessmentUpdateRestClient.pushUpdateToOasys(assessmentSchemaCode = AssessmentSchemaCode.RSR)
+    assertThat(updateAssessmentResponse).isEqualTo(null)
+  }
+
+  @Test
+  fun `Trying to push to OASys Assessment completion that should not be pushed into Oasys returns null`() {
+    val updateAssessmentResponse =
+      assessmentUpdateRestClient.pushCompleteToOasys(assessmentSchemaCode = AssessmentSchemaCode.RSR)
+    assertThat(updateAssessmentResponse).isEqualTo(null)
+  }
+
+  @Test
   fun `create OASys Assessment is Forbidden when OFF_ASSESSMENT_CREATE is not authorised`() {
     val exception =
       assertThrows<ExternalApiForbiddenException> {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCreateTest.kt
@@ -46,13 +46,11 @@ class AssessmentServiceCreateTest {
     episodeService,
     courtCaseRestClient,
     assessmentUpdateRestClient,
-    offenderService,
-    assessmentSchemaService
+    offenderService
   )
 
   private val assessmentUuid = UUID.randomUUID()
   private val assessmentId = 1L
-  private val assessmentType = OasysAssessmentType.SHORT_FORM_PSR
   private val assessmentSchemaCode = AssessmentSchemaCode.ROSH
 
   private val oasysOffenderPk = 1L

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -34,7 +34,6 @@ class AssessmentServiceTest {
   private val episodeService: EpisodeService = mockk()
   private val offenderService: OffenderService = mockk()
   private val assessmentUpdateRestClient: AssessmentUpdateRestClient = mockk()
-  private val assessmentSchemaService: AssessmentSchemaService = mockk()
 
   private val assessmentsService = AssessmentService(
     assessmentRepository,
@@ -43,8 +42,7 @@ class AssessmentServiceTest {
     episodeService,
     courtCaseRestClient,
     assessmentUpdateRestClient,
-    offenderService,
-    assessmentSchemaService
+    offenderService
   )
 
   private val assessmentUuid = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
@@ -56,8 +56,7 @@ class AssessmentUpdateServiceCompleteTest {
     episodeRepository,
     questionService,
     assessmentUpdateRestClient,
-    assessmentService,
-    assessmentSchemaService,
+    assessmentService
     predictorService,
   )
 
@@ -72,13 +71,13 @@ class AssessmentUpdateServiceCompleteTest {
     every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
     every { episodeRepository.save(any()) } returns assessment.episodes[0]
     every {
-      assessmentUpdateRestClient.completeAssessment(9999, OasysAssessmentType.SHORT_FORM_PSR, 7777)
+      assessmentUpdateRestClient.pushCompleteToOasys(9999, 7777, AssessmentSchemaCode.ROSH)
     } returns UpdateAssessmentAnswersResponseDto(7777)
 
     val episode = assessmentUpdateService.closeCurrentEpisode(UUID.fromString("7b4de6d5-4488-4c29-a909-7d3fdf15393d"))
 
     verify(exactly = 1) { episodeRepository.save(any()) }
-    verify(exactly = 1) { assessmentUpdateRestClient.completeAssessment(any(), any(), any(), any()) }
+    verify(exactly = 1) { assessmentUpdateRestClient.pushCompleteToOasys(9999, 7777, AssessmentSchemaCode.ROSH) }
     assertThat(episode.ended).isEqualToIgnoringMinutes(LocalDateTime.now())
   }
 
@@ -97,13 +96,13 @@ class AssessmentUpdateServiceCompleteTest {
     every { assessmentRepository.findByAssessmentUuid(any()) } returns assessment
     every { episodeRepository.save(any()) } returns assessment.episodes[0]
     every {
-      assessmentUpdateRestClient.completeAssessment(9999, OasysAssessmentType.SHORT_FORM_PSR, 7777)
+      assessmentUpdateRestClient.pushCompleteToOasys(9999, 7777, AssessmentSchemaCode.ROSH)
     } returns oasysAssessmentError()
 
     val episode = assessmentUpdateService.closeCurrentEpisode(UUID.fromString("7b4de6d5-4488-4c29-a909-7d3fdf15393d"))
 
     verify(exactly = 0) { episodeRepository.save(any()) }
-    verify(exactly = 1) { assessmentUpdateRestClient.completeAssessment(any(), any(), any(), any()) }
+    verify(exactly = 1) {  assessmentUpdateRestClient.pushCompleteToOasys(9999, 7777, AssessmentSchemaCode.ROSH) }
     assertThat(episode.ended).isNull()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
@@ -57,7 +57,7 @@ class AssessmentUpdateServiceCompleteTest {
     questionService,
     assessmentUpdateRestClient,
     assessmentService,
-    predictorService,
+    predictorService
   )
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
@@ -48,7 +48,6 @@ class AssessmentUpdateServiceCompleteTest {
     courtCaseRestClient,
     assessmentUpdateRestClient,
     offenderService,
-    assessmentSchemaService,
   )
 
   private val assessmentUpdateService = AssessmentUpdateService(

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCompleteTest.kt
@@ -56,7 +56,7 @@ class AssessmentUpdateServiceCompleteTest {
     episodeRepository,
     questionService,
     assessmentUpdateRestClient,
-    assessmentService
+    assessmentService,
     predictorService,
   )
 
@@ -102,7 +102,7 @@ class AssessmentUpdateServiceCompleteTest {
     val episode = assessmentUpdateService.closeCurrentEpisode(UUID.fromString("7b4de6d5-4488-4c29-a909-7d3fdf15393d"))
 
     verify(exactly = 0) { episodeRepository.save(any()) }
-    verify(exactly = 1) {  assessmentUpdateRestClient.pushCompleteToOasys(9999, 7777, AssessmentSchemaCode.ROSH) }
+    verify(exactly = 1) { assessmentUpdateRestClient.pushCompleteToOasys(9999, 7777, AssessmentSchemaCode.ROSH) }
     assertThat(episode.ended).isNull()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
@@ -33,7 +33,6 @@ class AssessmentUpdateServiceTest {
   private val courtCaseRestClient: CourtCaseRestClient = mockk()
   private val episodeService: EpisodeService = mockk()
   private val offenderService: OffenderService = mockk()
-  private val assessmentSchemaService: AssessmentSchemaService = mockk()
   private val predictorService: PredictorService = mockk()
 
   private val assessmentService = AssessmentService(
@@ -43,8 +42,7 @@ class AssessmentUpdateServiceTest {
     episodeService,
     courtCaseRestClient,
     assessmentUpdateRestClient,
-    offenderService,
-    assessmentSchemaService,
+    offenderService
   )
   private val assessmentUpdateService = AssessmentUpdateService(
     assessmentRepository,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
@@ -52,7 +52,6 @@ class AssessmentUpdateServiceTest {
     questionService,
     assessmentUpdateRestClient,
     assessmentService,
-    assessmentSchemaService,
     predictorService,
   )
 


### PR DESCRIPTION
Do not push update to assessments on updating an episode or completing an episode if assessment is anything else than ROSH. 

This is to allow standalone RSR to only be saved in the assessments-api database without ever trying to sync into oasys