### PR TITLE
Update to filter blanks when updating an episode

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/UpdateAssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/UpdateAssessmentEpisodeDto.kt
@@ -5,14 +5,17 @@ import java.util.UUID
 
 class UpdateAssessmentEpisodeDto(
   @Schema(description = "Answers associated with this episode")
-  val answers: Map<UUID, Collection<String>>
+  val answers: Map<UUID, Collection<String>> = emptyMap()
 ) {
+
   fun asAnswersDtos(): Map<UUID, AnswersDto> {
     return answers.mapValues { asAnswersDto(it.value) }
   }
+
   companion object {
     private fun asAnswersDto(ans: Collection<String>): AnswersDto {
-      return AnswersDto(listOf(AnswerDto(ans)))
+      val filteredAnswers = ans.filter { it.isNotBlank() }
+      return AnswersDto(listOf(AnswerDto(filteredAnswers)))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/AnswersDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/AnswersDtoTest.kt
@@ -14,9 +14,10 @@ class AnswersDtoTest {
     """.trimIndent()
 
     val deserialized = ObjectMapper().readValue(testAnswers, AnswersDto::class.java)
-    assertThat(deserialized.answers.size).isEqualTo(1)
-    assertThat(deserialized.answers.first().items.size).isEqualTo(1)
-    assertThat(deserialized.answers.first().items.first()).isEqualTo("TEST_ANSWER")
+    with (deserialized.answers) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(listOf("TEST_ANSWER"))
+    }
   }
 
   @Test
@@ -28,9 +29,20 @@ class AnswersDtoTest {
     """.trimIndent()
 
     val deserialized = ObjectMapper().readValue(testAnswers, AnswersDto::class.java)
-    assertThat(deserialized.answers.size).isEqualTo(1)
-    assertThat(deserialized.answers.first().items.size).isEqualTo(1)
-    assertThat(deserialized.answers.first().items.first()).isEqualTo("TEST_ANSWER")
+    with (deserialized.answers) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(listOf("TEST_ANSWER"))
+    }
+  }
+
+  @Test
+  fun `handles and empty list`() {
+    val testAnswers = """
+      []
+    """.trimIndent()
+
+    val deserialized = ObjectMapper().readValue(testAnswers, AnswersDto::class.java)
+    assertThat(deserialized.answers.size).isEqualTo(0)
   }
 
   @Test
@@ -42,8 +54,10 @@ class AnswersDtoTest {
     """.trimIndent()
 
     val deserialized = ObjectMapper().readValue(testAnswers, AnswersDto::class.java)
-    assertThat(deserialized.answers.size).isEqualTo(1)
-    assertThat(deserialized.answers.first().items.size).isEqualTo(0)
+    with (deserialized.answers) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(emptyList<AnswerDto>())
+    }
   }
 
   @Test
@@ -55,7 +69,24 @@ class AnswersDtoTest {
     """.trimIndent()
 
     val deserialized = ObjectMapper().readValue(testAnswers, AnswersDto::class.java)
-    assertThat(deserialized.answers.size).isEqualTo(1)
-    assertThat(deserialized.answers.first().items.size).isEqualTo(0)
+    with (deserialized.answers) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(emptyList<AnswerDto>())
+    }
+  }
+
+  @Test
+  fun `filters out empty answers when passed an empty list`() {
+    val testAnswers = """
+      [
+        []
+      ]
+    """.trimIndent()
+
+    val deserialized = ObjectMapper().readValue(testAnswers, AnswersDto::class.java)
+    with (deserialized.answers) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(emptyList<AnswerDto>())
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/UpdateAssessmentEpisodeDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/UpdateAssessmentEpisodeDtoTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.assessments.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class UpdateAssessmentEpisodeDtoTest {
+  @Test
+  fun `converts answers to AnswerDto`() {
+    val testAnswers = """
+     {
+        "answers": {
+          "00000000-0000-0000-0000-000000000000": [
+            "FOO",
+            "BAR"
+          ]
+        }
+    }
+    """.trimIndent()
+
+    val deserialized = ObjectMapper().readValue(testAnswers, UpdateAssessmentEpisodeDto::class.java)
+    val transformed = deserialized.asAnswersDtos()
+    val answersDto: AnswersDto? = transformed[UUID.fromString("00000000-0000-0000-0000-000000000000")]
+    with (answersDto?.answers!!) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(listOf("FOO", "BAR"))
+    }
+  }
+
+  @Test
+  fun `handles no answer values`() {
+    val testAnswers = """
+     {
+        "answers": {
+          "00000000-0000-0000-0000-000000000000": []
+        }
+    }
+    """.trimIndent()
+
+    val deserialized = ObjectMapper().readValue(testAnswers, UpdateAssessmentEpisodeDto::class.java)
+    val transformed = deserialized.asAnswersDtos()
+    val answersDto: AnswersDto? = transformed[UUID.fromString("00000000-0000-0000-0000-000000000000")]
+    with (answersDto?.answers!!) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(emptyList<AnswerDto>())
+    }
+  }
+
+  @Test
+  fun `filters out blank strings from answers`() {
+    val testAnswers = """
+     {
+        "answers": {
+          "00000000-0000-0000-0000-000000000000": [
+            ""
+          ]
+        }
+    }
+    """.trimIndent()
+
+    val deserialized = ObjectMapper().readValue(testAnswers, UpdateAssessmentEpisodeDto::class.java)
+    val transformed = deserialized.asAnswersDtos()
+    val answersDto: AnswersDto? = transformed[UUID.fromString("00000000-0000-0000-0000-000000000000")]
+    with (answersDto?.answers!!) {
+      assertThat(size).isEqualTo(1)
+      assertThat(first().items).isEqualTo(emptyList<AnswerDto>())
+    }
+  }
+}
+

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AnswerEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AnswerEntityTest.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.assessments.jpa.entities
+
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.assessments.api.AnswerDto
+
+@ExtendWith(MockKExtension::class)
+@DisplayName("Answer Entity Tests")
+class AnswerEntitiesTest {
+  @Nested
+  @DisplayName("Answer")
+  inner class AnswerTest {
+    @Test
+    fun `should construct when passed a list of strings`() {
+      val answerDto = AnswerDto(listOf("FOO", "BAR"))
+      val answer = Answer(answerDto.items)
+
+      with(answer.items) {
+        assertThat(size).isEqualTo(2)
+        assertThat(first()).isEqualTo("FOO")
+      }
+    }
+
+    @Test
+    fun `should construct when passed an empty list`() {
+      val answerDto = AnswerDto(emptyList())
+      val answer = Answer(answerDto.items)
+
+      assertThat(answer.items.size).isEqualTo(0)
+    }
+  }
+
+  @Nested
+  @DisplayName("Answer")
+  inner class AnswerEntityTest {
+    @Test
+    fun `should construct from a string`() {
+      val answerEntity = AnswerEntity.from("FOO")
+
+      with(answerEntity.answers) {
+        assertThat(size).isEqualTo(1)
+        assertThat(first().items).isEqualTo(listOf("FOO"))
+      }
+    }
+
+    @Test
+    fun `should construct from an empty list`() {
+      val answerEntity = AnswerEntity.from(emptyList())
+
+      assertThat(answerEntity.answers.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `should construct from a list of strings`() {
+      val answerEntity = AnswerEntity.from(listOf("FOO", "BAR"))
+
+      with(answerEntity.answers) {
+        assertThat(size).isEqualTo(2)
+        assertThat(first().items).isEqualTo(listOf("FOO"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Update the UpdateAssessmentEpisodeDto to filter blank strings
- Increase test coverage around Answer DTOs