### PR TITLE
Add Gotenberg as a dependency to the Helm Chart

### DIFF
--- a/helm_deploy/hmpps-assessments-api/Chart.yaml
+++ b/helm_deploy/hmpps-assessments-api/Chart.yaml
@@ -3,3 +3,8 @@ appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: hmpps-assessments-api
 version: 0.1.0
+
+dependencies:
+  - name: gotenberg
+    version: 0.1.0
+    repository: file://charts/gotenberg

--- a/helm_deploy/hmpps-assessments-api/Chart.yaml
+++ b/helm_deploy/hmpps-assessments-api/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
-description: A Helm chart for Kubernetes
+description: Helm chart for the HMPPS Assessments API
 name: hmpps-assessments-api
 version: 0.1.0
 

--- a/helm_deploy/hmpps-assessments-api/charts/gotenberg/.helmignore
+++ b/helm_deploy/hmpps-assessments-api/charts/gotenberg/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm_deploy/hmpps-assessments-api/charts/gotenberg/Chart.yaml
+++ b/helm_deploy/hmpps-assessments-api/charts/gotenberg/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gotenberg
+description: A Helm chart Gotenberg
+type: application
+version: 0.1.0
+appVersion: "6.4.4"

--- a/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/NOTES.txt
+++ b/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/NOTES.txt
@@ -1,0 +1,8 @@
+1. Get the application URL by running these commands:
+ Gotenberg deployed to the namespace and is running on {{ .Values.image.port }}, to access:
+
+ "kubectl port-forward {{ include "gotenberg.fullname" . }} {{ .Values.image.port }}:{{ .Values.image.port }}"
+
+ Or internally within the namespace via:
+
+ "{{ include "gotenberg.fullname" . }}.{{ .Release.namespace }}.svc.cluster.local"

--- a/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/_helpers.tpl
+++ b/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gotenberg.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gotenberg.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gotenberg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gotenberg.labels" -}}
+helm.sh/chart: {{ include "gotenberg.chart" . }}
+{{ include "gotenberg.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gotenberg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gotenberg.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gotenberg.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gotenberg.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/deployment.yaml
+++ b/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 50%
+  selector:
+    matchLabels:
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gotenberg.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ template "gotenberg.name" . }}
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.image.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.image.port }}
+            periodSeconds: 30
+            initialDelaySeconds: 90
+            timeoutSeconds: 20
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.image.port }}
+            periodSeconds: 20
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 15

--- a/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/service.yaml
+++ b/helm_deploy/hmpps-assessments-api/charts/gotenberg/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gotenberg.selectorLabels" . | nindent 4 }}

--- a/helm_deploy/hmpps-assessments-api/charts/gotenberg/values.yaml
+++ b/helm_deploy/hmpps-assessments-api/charts/gotenberg/values.yaml
@@ -1,0 +1,16 @@
+# Default values for gotenberg.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: thecodingmachine/gotenberg
+  port: 3000
+  pullPolicy: IfNotPresent
+
+securityContext:
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,3 +21,6 @@ env:
   ASSESSMENT_API_BASE_URL: https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_BASE_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/
   SPRING_PROFILES_ACTIVE: "logstash,postgres"
+
+gotenberg:
+  replicaCount: 1


### PR DESCRIPTION
## Background

This PR adds Gotenberg as a side-car deployment to the Helm chart for the `hmpps-assessments-api` this will be available on `hmpps-assessments-api-gotenberg.hmpps-assessments-dev.svc.cluster.local:3000`. 