### PR TITLE
add gender to subject table for predictor calculations and update tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentSubjectDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentSubjectDto.kt
@@ -23,6 +23,9 @@ class AssessmentSubjectDto(
   @Schema(description = "Date of birth", example = "1929-08-08")
   val dob: LocalDate? = null,
 
+  @Schema(description = "Date of birth", example = "1929-08-08")
+  val gender: String? = null,
+
   @Schema(description = "Subject Record created Date", example = "2020-01-02T16:00:00")
   val createdDate: LocalDateTime? = null,
 ) {
@@ -37,6 +40,7 @@ class AssessmentSubjectDto(
         subject.pnc,
         subject.crn,
         subject.dateOfBirth,
+        subject.gender,
         subject.createdDate
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/SubjectEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/SubjectEntity.kt
@@ -45,6 +45,9 @@ class SubjectEntity(
   @Column(name = "DATE_OF_BIRTH")
   val dateOfBirth: LocalDate,
 
+  @Column(name = "GENDER")
+  val gender: String? = null,
+
   @Column(name = "CREATED_DATE")
   val createdDate: LocalDateTime? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/PredictorService.kt
@@ -72,11 +72,12 @@ class PredictorService(
       ?: throw EntityNotFoundException("Episode ${episode.episodeUuid} is not associated with an assessment")
     val offender = subjectService.getSubjectForAssessment(assessmentUuid)
     val crn = offender.crn
+    if (offender.gender == null) throw PredictorCalculationException("The risk predictors calculation failed for crn $crn: gender must not be null")
     log.info("Getting Predictor Score for crn $crn and type $predictorType")
     val hasCompletedInterview = getRequiredAnswer(answers, "completed_interview").toBoolean()
     val offenderAndOffencesDto = OffenderAndOffencesDto(
       crn = crn,
-      gender = Gender.MALE,
+      gender = Gender.valueOf(offender.gender!!),
       dob = offender.dateOfBirth,
       assessmentDate = episode.createdDate,
       currentOffence = CurrentOffence("138", "00"),

--- a/src/main/resources/db/migration/V1_10__subject_gender.sql
+++ b/src/main/resources/db/migration/V1_10__subject_gender.sql
@@ -1,0 +1,2 @@
+ALTER TABLE subject
+ADD COLUMN gender TEXT;

--- a/src/main/resources/db/testdata/afterMigrate.sql
+++ b/src/main/resources/db/testdata/afterMigrate.sql
@@ -2,8 +2,8 @@ INSERT INTO assessment (assessment_uuid, created_date, completed_date )
 VALUES ('fb6b7c33-07fc-4c4c-a009-8d60f66952c4', '2019-11-14 08:11:53.177108', null)
 ON CONFLICT DO NOTHING;
 
-insert into subject (subject_uuid, source, source_id, name, pnc, crn, date_of_birth, created_date, assessment_uuid, OASYS_OFFENDER_PK) values
-('fac28f68-0012-46b9-8de8-6ff2bdbe1c22', 'DELIUS', 1, 'EleRgvLL JanRgvDD', null, 'X259950', '1977-08-15', '2021-07-12 16:42:06', 'fb6b7c33-07fc-4c4c-a009-8d60f66952c4', 7308807)
+insert into subject (subject_uuid, source, source_id, name, pnc, crn, date_of_birth, gender, created_date, assessment_uuid, OASYS_OFFENDER_PK) values
+('fac28f68-0012-46b9-8de8-6ff2bdbe1c22', 'DELIUS', 1, 'EleRgvLL JanRgvDD', null, 'X259950', '1977-08-15', 'MALE', '2021-07-12 16:42:06', 'fb6b7c33-07fc-4c4c-a009-8d60f66952c4', 7308807)
 ON CONFLICT DO NOTHING;
 
 INSERT INTO assessed_episode (episode_uuid, user_id, created_date, end_date, change_reason, assessment_schema_code, assessment_uuid, answers, OASYS_SET_PK  )
@@ -16,8 +16,8 @@ INSERT INTO assessment (assessment_uuid, created_date, completed_date )
 VALUES ('6f3f2c4a-38ac-49ce-b790-70bc170fe553', '2021-01-01 08:11:53.177108', null)
 ON CONFLICT DO NOTHING;
 
-insert into subject (subject_uuid, source, source_id, name, pnc, crn, date_of_birth, created_date, assessment_uuid) values
-('087bdec0-98de-4c86-af3d-2d05ff978007', 'DELIUS', 1, 'EleRgvLL JanRgvDD', null, 'X259950', '1977-08-15', '2021-07-12 16:42:06', '6f3f2c4a-38ac-49ce-b790-70bc170fe553')
+insert into subject (subject_uuid, source, source_id, name, pnc, crn, date_of_birth, gender, created_date, assessment_uuid) values
+('087bdec0-98de-4c86-af3d-2d05ff978007', 'DELIUS', 1, 'EleRgvLL JanRgvDD', null, 'X259950', '1977-08-15', 'MALE', '2021-07-12 16:42:06', '6f3f2c4a-38ac-49ce-b790-70bc170fe553')
 ON CONFLICT DO NOTHING;
 
 INSERT INTO assessed_episode (episode_uuid, user_id, created_date, end_date, change_reason, assessment_schema_code, assessment_uuid, answers  )

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/PredictorServiceTest.kt
@@ -282,7 +282,7 @@ class PredictorServiceTest {
       every {
         subjectService.getSubjectForAssessment(assessment.assessmentUuid)
       } returns SubjectEntity(
-        oasysOffenderPk = 9999, dateOfBirth = LocalDate.of(2001, 1, 1), crn = "X1345"
+        oasysOffenderPk = 9999, dateOfBirth = LocalDate.of(2001, 1, 1), gender = "MALE", crn = "X1345"
       )
 
       assertThrows<EntityNotFoundException> {
@@ -299,7 +299,7 @@ class PredictorServiceTest {
 
       val offenderAndOffencesDto = OffenderAndOffencesDto(
         crn = "X1345",
-        gender = Gender.MALE,
+        gender = Gender.FEMALE,
         dob = LocalDate.of(2001, 1, 1),
         assessmentDate = assessmentEpisode.createdDate,
         currentOffence = CurrentOffence("138", "00"),
@@ -334,7 +334,7 @@ class PredictorServiceTest {
       every {
         subjectService.getSubjectForAssessment(assessment.assessmentUuid)
       } returns SubjectEntity(
-        oasysOffenderPk = 9999, dateOfBirth = LocalDate.of(2001, 1, 1), crn = "X1345"
+        oasysOffenderPk = 9999, dateOfBirth = LocalDate.of(2001, 1, 1), gender = "FEMALE", crn = "X1345"
       )
 
       val results = predictorService.getPredictorResults(AssessmentSchemaCode.RSR, assessmentEpisode)

--- a/src/test/resources/assessments/before-test.sql
+++ b/src/test/resources/assessments/before-test.sql
@@ -22,8 +22,8 @@ INSERT INTO assessment  (assessment_id, assessment_uuid, created_date) VALUES
 (1, '2e020e78-a81c-407f-bc78-e5f284e237e5', '2019-11-14 09:00'),
 (2, '19c8d211-68dc-4692-a6e2-d58468127056', '2019-11-14 09:00');
 
-INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, created_date, assessment_uuid) VALUES
-(1, 'a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056');
+INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, gender, created_date, assessment_uuid) VALUES
+(1, 'a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056');
 
 INSERT INTO assessed_episode  (episode_id, episode_uuid, user_id, created_date, end_date, change_reason, assessment_uuid, answers) VALUES
 (1, 'd7aafe55-0cff-4f20-a57a-b66d79eb9c91', 'USER1', '2019-11-14 09:00', '2019-11-14 12:00','Change of Circs', '2e020e78-a81c-407f-bc78-e5f284e237e5', '{}'),
@@ -39,10 +39,10 @@ INSERT INTO assessment  (assessment_id, assessment_uuid, created_date) VALUES
 (5, '6082265e-885d-4526-b713-77e59b70691e', '2020-1-14 09:00'),
 (6, 'aa47e6c4-e41f-467c-95e7-fcf5ffd422f5', '2020-1-14 09:00');
 
-INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, oasys_offender_pk, pnc, crn, date_of_birth, created_date, assessment_uuid) VALUES
-(3, '7bce2323-fefa-42eb-b622-ec65747aae56', 'COURT', 'courtCode|caseNumber2', 'John Smith', 1, 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', 'e399ed1b-0e77-4c68-8bbc-d2f0befece84'),
-(4, '1146f644-dfb9-4e6d-9446-1be089538480', 'COURT', 'courtCode|caseNumber3', 'John Smith', 12345, 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', '6082265e-885d-4526-b713-77e59b70691e'),
-(5, 'f6023241-ba22-47e4-bc7d-f7adfde4276c', 'COURT', 'courtCode|caseNumber3', 'John Smith', 5, 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', 'aa47e6c4-e41f-467c-95e7-fcf5ffd422f5');
+INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, oasys_offender_pk, pnc, crn, date_of_birth, gender, created_date, assessment_uuid) VALUES
+(3, '7bce2323-fefa-42eb-b622-ec65747aae56', 'COURT', 'courtCode|caseNumber2', 'John Smith', 1, 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', 'e399ed1b-0e77-4c68-8bbc-d2f0befece84'),
+(4, '1146f644-dfb9-4e6d-9446-1be089538480', 'COURT', 'courtCode|caseNumber3', 'John Smith', 12345, 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', '6082265e-885d-4526-b713-77e59b70691e'),
+(5, 'f6023241-ba22-47e4-bc7d-f7adfde4276c', 'COURT', 'courtCode|caseNumber3', 'John Smith', 5, 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', 'aa47e6c4-e41f-467c-95e7-fcf5ffd422f5');
 
 INSERT INTO assessed_episode  (episode_id, episode_uuid, user_id, assessment_schema_code, oasys_set_pk, created_date, end_date, change_reason, assessment_uuid, answers) VALUES
 (3, '163cf020-ff53-4dc6-a15c-e93e8537d347', 'USER1', 'ROSH', 1, '2019-11-14 09:00', null, 'More Change of Circs', 'e399ed1b-0e77-4c68-8bbc-d2f0befece84', '{}'),
@@ -50,8 +50,8 @@ INSERT INTO assessed_episode  (episode_id, episode_uuid, user_id, assessment_sch
 (5, '4f99ea18-6559-460e-9693-68f0f5e5bebc', 'USER1', 'ROSH', 1, '2019-11-14 09:00', null, 'More Change of Circs', 'aa47e6c4-e41f-467c-95e7-fcf5ffd422f5', '{}');
 
 /* Existing Delius Subject */
-INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, created_date, assessment_uuid) VALUES
-(6, '362aae3c-852d-4a39-80f4-f41adc249bae', 'DELIUS', '12345', 'John Smith', 'dummy-pnc', 'CRN1', '1928-08-01', '2019-11-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056');
+INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, gender, created_date, assessment_uuid) VALUES
+(6, '362aae3c-852d-4a39-80f4-f41adc249bae', 'DELIUS', '12345', 'John Smith', 'dummy-pnc', 'CRN1', '1928-08-01', 'MALE', '2019-11-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056');
 
 INSERT INTO grouping (group_uuid, group_code, heading, subheading, help_text, group_start, group_end)
 VALUES ('fb777be0-a183-4c83-8209-e7871df9c547', 'children_at_risk_of_serious_harm', 'Children at Risk of Serious Harm', null, null, '2020-11-30 14:50:00', null);

--- a/src/test/resources/filteredReferenceData/before-test.sql
+++ b/src/test/resources/filteredReferenceData/before-test.sql
@@ -21,12 +21,12 @@ INSERT INTO assessment  (assessment_id, assessment_uuid, created_date) VALUES
 (4, '80fd9a2a-59dd-4783-8cac-1689a0464437', '2019-11-14 09:00'),
 (5, '8177b6c7-1b20-459b-b6ee-0aeeb2f16857', '2019-11-14 09:00');
 
-INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, created_date, assessment_uuid) VALUES
-(1, 'a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', '2e020e78-a81c-407f-bc78-e5f284e237e5'),
-(2, 'bf1979c5-518a-4300-80f2-189981182e5f', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', 'bbbae903-7803-4206-800c-2d3b81116d5c'),
-(3, 'f0c3c497-b0b8-4fe1-9749-2f686b3b1aa0', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', 'bd5e5a88-c0ac-4f55-9c08-b8e8bdd9568c'),
-(4, 'a2bb4345-beba-4806-b719-6cc4ae52ee43', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', '80fd9a2a-59dd-4783-8cac-1689a0464437'),
-(5, '36afe601-a2d9-4e32-b921-1c20fd0befef', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', '8177b6c7-1b20-459b-b6ee-0aeeb2f16857');
+INSERT INTO subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, gender, created_date, assessment_uuid) VALUES
+(1, 'a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', '2e020e78-a81c-407f-bc78-e5f284e237e5'),
+(2, 'bf1979c5-518a-4300-80f2-189981182e5f', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', 'bbbae903-7803-4206-800c-2d3b81116d5c'),
+(3, 'f0c3c497-b0b8-4fe1-9749-2f686b3b1aa0', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', 'bd5e5a88-c0ac-4f55-9c08-b8e8bdd9568c'),
+(4, 'a2bb4345-beba-4806-b719-6cc4ae52ee43', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', '80fd9a2a-59dd-4783-8cac-1689a0464437'),
+(5, '36afe601-a2d9-4e32-b921-1c20fd0befef', 'COURT', 'courtCode|caseNumber', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', '8177b6c7-1b20-459b-b6ee-0aeeb2f16857');
 
 INSERT INTO assessed_episode  (episode_id, episode_uuid, user_id, created_date, end_date, change_reason, assessment_uuid, answers, oasys_set_pk) VALUES
 (1, '8efd9267-e399-48f1-9402-51a08e245f3b', 'USER1', '2019-11-14 09:00', null,'Change of Circs', '2e020e78-a81c-407f-bc78-e5f284e237e5', '{}', 1),

--- a/src/test/resources/subject/before-test.sql
+++ b/src/test/resources/subject/before-test.sql
@@ -9,7 +9,7 @@ insert into assessment  (assessment_id, assessment_uuid, created_date) values
 (1, '2e020e78-a81c-407f-bc78-e5f284e237e5', '2019-11-14 09:00'),
 (2, '19c8d211-68dc-4692-a6e2-d58468127056', '2019-11-14 09:00');
 
-insert into subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, created_date, assessment_uuid) values
-(1, 'a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'COURT', 'courtCode|caseNumber1', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2019-11-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056'),
-(2, '8a16598c-e175-417e-afd4-4d2b4cf4313e', 'COURT', 'courtCode|caseNumber2', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', '2020-11-14 08:30', '2e020e78-a81c-407f-bc78-e5f284e237e5'),
-(3, '3d224d7e-c29c-44d7-86d5-0816764889ee', 'COURT', 'SHF06|668911253', 'John Smith', 'dummy-pnc', 'DX12340A', '1928-08-01', '2021-1-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056');
+insert into subject (subject_id, subject_uuid, source, source_id, name, pnc, crn, date_of_birth, gender, created_date, assessment_uuid) values
+(1, 'a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'COURT', 'courtCode|caseNumber1', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2019-11-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056'),
+(2, '8a16598c-e175-417e-afd4-4d2b4cf4313e', 'COURT', 'courtCode|caseNumber2', 'John Smith', 'dummy-pnc', 'dummy-crn', '1928-08-01', 'MALE', '2020-11-14 08:30', '2e020e78-a81c-407f-bc78-e5f284e237e5'),
+(3, '3d224d7e-c29c-44d7-86d5-0816764889ee', 'COURT', 'SHF06|668911253', 'John Smith', 'dummy-pnc', 'DX12340A', '1928-08-01', 'MALE', '2021-1-14 08:30', '19c8d211-68dc-4692-a6e2-d58468127056');


### PR DESCRIPTION
This PR removes the hardcoded gender variable in the predictors calculation. 
It adds the gender field to the subject table and is provided from the community api, which is then used in the predictors calculation in the predictors service.