### PR TITLE
add static and dynamic score type to predictors response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoresDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/PredictorScoresDto.kt
@@ -2,11 +2,15 @@ package uk.gov.justice.digital.assessments.api
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
+import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import java.math.BigDecimal
 
 data class PredictorScoresDto(
   @Schema(description = "Predictor type", example = "RSR")
   val type: PredictorType,
+
+  @Schema(description = "Predictor type", example = "RSR")
+  val scoreType: ScoreType,
 
   @Schema(description = "Predictor scores")
   val scores: Map<String, Score>,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskPredictorsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskPredictorsDto.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi
 
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
+import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import java.math.BigDecimal
 
 data class RiskPredictorsDto(
   val calculatedAt: String,
   val type: PredictorType,
-  val scoreType: ScoreType?,
+  val scoreType: ScoreType,
   val scores: Map<PredictorSubType, Score>,
   val errors: List<String> = emptyList()
 )
@@ -22,16 +23,6 @@ enum class ScoreLevel(val type: String) {
 
   companion object {
     fun findByType(type: String): ScoreLevel? {
-      return values().firstOrNull { value -> value.type == type }
-    }
-  }
-}
-
-enum class ScoreType(val type: String) {
-  STATIC("Static"), DYNAMIC("Dynamic");
-
-  companion object {
-    fun findByType(type: String): ScoreType? {
       return values().firstOrNull { value -> value.type == type }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
@@ -175,6 +175,7 @@ class RiskPredictorsService(
     if (this == null) throw PredictorCalculationException("The risk predictors calculation failed for crn $crn")
     return PredictorScoresDto(
       type = this.type,
+      scoreType = this.scoreType,
       scores = this.toRiskPredictorsScores()
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/ScoreType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/dto/ScoreType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.assessments.services.dto
+
+enum class ScoreType {
+  STATIC, DYNAMIC
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
+import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 import uk.gov.justice.digital.assessments.testutils.Verify
 import uk.gov.justice.digital.assessments.utils.RequestData
@@ -449,6 +450,7 @@ class AssessmentControllerTest : IntegrationTest() {
         listOf(
           PredictorScoresDto(
             type = PredictorType.RSR,
+            scoreType = ScoreType.STATIC,
             scores = mapOf(
               PredictorSubType.RSR.name to Score(
                 level = ScoreLevel.HIGH.name,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/RiskPredictorsControllerTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.assessments.api.Score
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
+import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 import java.math.BigDecimal
 import java.util.UUID
@@ -48,6 +49,7 @@ class RiskPredictorsControllerTest : IntegrationTest() {
       listOf(
         PredictorScoresDto(
           type = PredictorType.RSR,
+          scoreType = ScoreType.STATIC,
           scores = mapOf(
             PredictorSubType.RSR.name to Score(
               level = ScoreLevel.HIGH.name,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessRisksAndNeedsApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessRisksAndNeedsApiClientTest.kt
@@ -21,8 +21,8 @@ import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Prob
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.RiskPredictorsDto
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Score
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreType
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
+import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 import java.math.BigDecimal
 import java.time.LocalDate

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.assessments.jpa.repositories.assessments.Assessmen
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
+import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
 import java.math.BigDecimal
 import java.util.UUID
@@ -94,6 +95,7 @@ class AssessmentUpdateServiceITTest() : IntegrationTest() {
         listOf(
           PredictorScoresDto(
             type = PredictorType.RSR,
+            scoreType = ScoreType.STATIC,
             scores = mapOf(
               PredictorSubType.RSR.name to Score(
                 level = ScoreLevel.HIGH.name,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsServiceTest.kt
@@ -29,8 +29,8 @@ import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Prev
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.RiskPredictorsDto
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Score
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreType
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
+import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -722,7 +722,6 @@ class RiskPredictorsServiceTest {
       assertThrows<EntityNotFoundException> {
         predictorService.getPredictorResults(episodeUuid, final)
       }
-
     }
   }
 


### PR DESCRIPTION
GET `/risks/predictors/episodes/{episodeUuid}` should now return `scoreType` - DYNAMIC, STATIC
```

data class PredictorScoresDto(
  @Schema(description = "Predictor type", example = "RSR")
  val type: PredictorType,

  @Schema(description = "Predictor type", example = "RSR")
  val scoreType: ScoreType,

  @Schema(description = "Predictor scores")
  val scores: Map<String, Score>,
)
```
