### PR TITLE
Validate Delius LAO user access to offender data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/ErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/ErrorResponse.kt
@@ -18,7 +18,7 @@ data class ErrorResponse(
   val userMessage: String? = null,
 
   @Schema(required = false, description = "Additional information about the error", example = "Hard disk failure")
-  val moreInfo: String? = null,
+  val moreInfo: List<String> = emptyList(),
 
   @Schema(required = false, description = "Reason for exception", example = "OASYS_PERMISSION")
   val reason: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/RiskPredictorsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/RiskPredictorsController.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
@@ -26,6 +27,7 @@ class RiskPredictorsController(val riskPredictorsService: RiskPredictorsService)
       ApiResponse(responseCode = "200", description = "OK")
     ]
   )
+  @PreAuthorize("hasRole('ROLE_PROBATION')")
   fun calculateRiskPredictorsForEpisode(
     @Parameter(description = "Episode UUID", required = true, example = "90f2b674-ae1c-488d-8b85-0251708ef6b6")
     @PathVariable episodeUuid: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiRestClient.kt
@@ -173,7 +173,7 @@ class AssessmentApiRestClient {
               method = method,
               url = url,
               client = ExternalService.ASSESSMENTS_API,
-              moreInfo = error.payload?.permissions?.get(0)?.returnMessage,
+              moreInfo = listOfNotNull(error.payload?.permissions?.get(0)?.returnMessage),
               reason = ExceptionReason.OASYS_PERMISSION
             )
           }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/UserAccessResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/UserAccessResponse.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.assessments.restclient.communityapi
+
+data class UserAccessResponse(
+  val exclusionMessage: String?,
+  val restrictionMessage: String?,
+  val userExcluded: Boolean,
+  val userRestricted: Boolean
+)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentUpdateService.kt
@@ -31,7 +31,7 @@ class OasysAssessmentUpdateService(
     updatedEpisodeAnswers: Answers,
   ): AssessmentEpisodeUpdateErrors {
     val offenderPk = episode.assessment?.subject?.oasysOffenderPk
-    if (episode.assessmentSchemaCode == null || episode.oasysSetPk == null || offenderPk == null) {
+    if (episode.oasysSetPk == null || offenderPk == null) {
       val errorMessage =
         "Unable to update OASys Assessment with keys type: ${episode.assessmentSchemaCode} oasysSet: ${episode.oasysSetPk} offenderPk: $offenderPk, values cant be null"
       log.error(errorMessage)
@@ -71,8 +71,8 @@ class OasysAssessmentUpdateService(
   fun completeOASysAssessment(
     episode: AssessmentEpisodeEntity,
     offenderPk: Long?,
-  ): AssessmentEpisodeUpdateErrors? {
-    if (episode.assessmentSchemaCode == null || episode.oasysSetPk == null || offenderPk == null) {
+  ): AssessmentEpisodeUpdateErrors {
+    if (episode.oasysSetPk == null || offenderPk == null) {
       val errorMessage =
         "Unable to complete OASys Assessment with keys type: ${episode.assessmentSchemaCode} oasysSet: ${episode.oasysSetPk} offenderPk: $offenderPk, values cant be null"
       log.error(errorMessage)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/OffenderService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.assessments.api.OffenderDto
 import uk.gov.justice.digital.assessments.restclient.CommunityApiRestClient
 import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
+import uk.gov.justice.digital.assessments.utils.RequestData
 
 @Service
 class OffenderService(
@@ -38,6 +39,10 @@ class OffenderService(
     val conviction = convictions.find { it.index == eventId }
       ?: throw EntityNotFoundException("Could not get conviction for crn: $crn, event ID: $eventId")
     return OffenceDto.from(conviction)
+  }
+
+  fun validateUserAccess(crn: String) {
+    communityApiRestClient.verifyUserAccess(crn, RequestData.getUserName())
   }
 
 //  fun getOffenderAddress(crn: String): Address? {

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
@@ -30,7 +30,8 @@ class RiskPredictorsService(
   private val assessmentSchemaService: AssessmentSchemaService,
   private val subjectService: SubjectService,
   private val episodeRepository: EpisodeRepository,
-  private val assessRisksAndNeedsApiRestClient: AssessRisksAndNeedsApiRestClient
+  private val assessRisksAndNeedsApiRestClient: AssessRisksAndNeedsApiRestClient,
+  private val offenderService: OffenderService
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -39,6 +40,7 @@ class RiskPredictorsService(
   fun getPredictorResults(episodeUuid: UUID, final: Boolean = false): List<PredictorScoresDto> {
     val episode = episodeRepository.findByEpisodeUuid(episodeUuid)
       ?: throw EntityNotFoundException("Episode with $episodeUuid not found")
+    episode.assessment?.subject?.crn?.let { offenderService.validateUserAccess(it) }
     return getPredictorResults(episode)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.assessments.services.exceptions.ExceptionReason.OA
 enum class ExceptionReason {
   OASYS_PERMISSION,
   DUPLICATE_OFFENDER_RECORD,
+  LAO_PERMISSION
 }
 
 // Internal Service Exceptions
@@ -52,7 +53,7 @@ class ExternalApiForbiddenException(
   val method: HttpMethod,
   val url: String,
   val client: ExternalService,
-  val moreInfo: String? = null,
+  val moreInfo: List<String> = emptyList(),
   val reason: ExceptionReason? = null
 ) : RuntimeException(msg)
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
@@ -156,6 +156,26 @@ class AssessmentControllerCreateTest : IntegrationTest() {
     }
 
     @Test
+    fun `should return forbidden when user does not have LAO permissions on offender`() {
+      webTestClient.post().uri("/assessments")
+        .bodyValue(
+          CreateAssessmentDto(
+            crn = "OX1232456",
+            deliusEventId = eventID,
+            assessmentSchemaCode = AssessmentSchemaCode.ROSH
+          )
+        )
+        .headers(setAuthorisation(roles = listOf("ROLE_PROBATION")))
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody<ErrorResponse>()
+        .consumeWith {
+          assertThat(it.responseBody?.status).isEqualTo(403)
+          assertThat(it.responseBody?.reason).isEqualTo("LAO_PERMISSION")
+        }
+    }
+
+    @Test
     fun `creating a new assessment from crn and delius event id returns assessment`() {
 
       val dto = CreateAssessmentDto(

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessmentApiTest.kt
@@ -60,7 +60,7 @@ class AssessmentApiTest : IntegrationTest() {
     org.junit.jupiter.api.Assertions.assertEquals(exception.client, ExternalService.ASSESSMENTS_API)
     org.junit.jupiter.api.Assertions.assertEquals(
       exception.moreInfo,
-      "STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021."
+      listOf("STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021.")
     )
     org.junit.jupiter.api.Assertions.assertEquals(exception.reason, ExceptionReason.OASYS_PERMISSION)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.assessments.restclient
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,70 +18,126 @@ class CommunityApiClientTest : IntegrationTest() {
   @Autowired
   internal lateinit var communityApiRestClient: CommunityApiRestClient
 
-  val crn = "DX12340A"
+  @Nested
+  @DisplayName("get Delius offender details")
+  inner class GetDeliusOffenderDetails {
 
-  @Test
-  fun `get Delius Offender returns offender DTO`() {
-    val offenderDto = communityApiRestClient.getOffender(crn)
-    assertThat(offenderDto?.offenderId).isEqualTo(101L)
-    assertThat(offenderDto?.otherIds?.crn).isEqualTo(crn)
-  }
+    val crn = "DX12340A"
 
-  @Test
-  fun `get Delius Offender returns not found`() {
-    assertThrows<ExternalApiEntityNotFoundException> {
-      communityApiRestClient.getOffender("invalidNotFound")
+    @Test
+    fun `get Delius Offender returns offender DTO`() {
+      val offenderDto = communityApiRestClient.getOffender(crn)
+      assertThat(offenderDto?.offenderId).isEqualTo(101L)
+      assertThat(offenderDto?.otherIds?.crn).isEqualTo(crn)
+    }
+
+    @Test
+    fun `get Delius Offender returns not found`() {
+      assertThrows<ExternalApiEntityNotFoundException> {
+        communityApiRestClient.getOffender("invalidNotFound")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns bad request`() {
+      assertThrows<ExternalApiInvalidRequestException> {
+        communityApiRestClient.getOffender("invalidBadRequest")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns unauthorised`() {
+      assertThrows<ExternalApiAuthorisationException> {
+        communityApiRestClient.getOffender("invalidUnauthorized")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns forbidden`() {
+      assertThrows<ExternalApiForbiddenException> {
+        communityApiRestClient.getOffender("invalidForbidden")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns unknown exception`() {
+      assertThrows<ExternalApiUnknownException> {
+        communityApiRestClient.getOffender("invalidNotKnow")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns offender DTO with aliases`() {
+      val offenderDto = communityApiRestClient.getOffender(crn)
+      assertThat(offenderDto?.offenderAliases?.get(0)?.firstName).isEqualTo("John")
+      assertThat(offenderDto?.offenderAliases?.get(0)?.surname).isEqualTo("Smithy")
+    }
+
+    @Test
+    fun `get Delius Conviction returns conviction DTO`() {
+      val convictions = communityApiRestClient.getConvictions(crn)
+      assertThat(convictions?.get(0)?.convictionId).isEqualTo(2500000223L)
+
+      assertThat(convictions?.get(0)?.offences?.get(0)?.mainOffence).isEqualTo(true)
+      assertThat(convictions?.get(0)?.offences?.get(0)?.offenceId).isEqualTo("M2500000223")
+
+      assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.mainCategoryCode).isEqualTo("046")
+      assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.mainCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
+      assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.subCategoryCode).isEqualTo("00")
+      assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.subCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
+
+      assertThat(convictions?.get(0)?.sentence?.startDate).isEqualTo(LocalDate.of(2014, 8, 25))
     }
   }
 
-  @Test
-  fun `get Delius Offender returns bad request`() {
-    assertThrows<ExternalApiInvalidRequestException> {
-      communityApiRestClient.getOffender("invalidBadRequest")
+  @Nested
+  @DisplayName("Delius LAO rules")
+  inner class DeliusLAORules {
+
+    val validCRN = "DX12340A"
+    val invalidCRN = "OX123456"
+
+    @Test
+    fun `verify Offender Access returns DTO`() {
+      val userAccessDto = communityApiRestClient.verifyUserAccess(validCRN, "USER")
+      assertThat(userAccessDto.userExcluded).isFalse()
+      assertThat(userAccessDto.userRestricted).isFalse()
     }
-  }
 
-  @Test
-  fun `get Delius Offender returns unauthorised`() {
-    assertThrows<ExternalApiAuthorisationException> {
-      communityApiRestClient.getOffender("invalidUnauthorized")
+    @Test
+    fun `verify Offender Access returns forbidden`() {
+      val exception = assertThrows<ExternalApiForbiddenException> {
+        communityApiRestClient.verifyUserAccess(invalidCRN, "user1")
+      }
+      assertThat(exception.moreInfo).containsAll(listOf("excluded", "restricted"))
     }
-  }
 
-  @Test
-  fun `get Delius Offender returns forbidden`() {
-    assertThrows<ExternalApiForbiddenException> {
-      communityApiRestClient.getOffender("invalidForbidden")
+    @Test
+    fun `verify Offender Access not found`() {
+      assertThrows<ExternalApiEntityNotFoundException> {
+        communityApiRestClient.verifyUserAccess("invalidNotFound", "user1")
+      }
     }
-  }
 
-  @Test
-  fun `get Delius Offender returns unknown exception`() {
-    assertThrows<ExternalApiUnknownException> {
-      communityApiRestClient.getOffender("invalidNotKnow")
+    @Test
+    fun `verify Offender Access bad request`() {
+      assertThrows<ExternalApiInvalidRequestException> {
+        communityApiRestClient.verifyUserAccess("invalidBadRequest", "user1")
+      }
     }
-  }
 
-  @Test
-  fun `get Delius Offender returns offender DTO with aliases`() {
-    val offenderDto = communityApiRestClient.getOffender(crn)
-    assertThat(offenderDto?.offenderAliases?.get(0)?.firstName).isEqualTo("John")
-    assertThat(offenderDto?.offenderAliases?.get(0)?.surname).isEqualTo("Smithy")
-  }
+    @Test
+    fun `verify Offender Access returns unauthorised`() {
+      assertThrows<ExternalApiAuthorisationException> {
+        communityApiRestClient.verifyUserAccess("invalidUnauthorized", "user1")
+      }
+    }
 
-  @Test
-  fun `get Delius Conviction returns conviction DTO`() {
-    val convictions = communityApiRestClient.getConvictions(crn)
-    assertThat(convictions?.get(0)?.convictionId).isEqualTo(2500000223L)
-
-    assertThat(convictions?.get(0)?.offences?.get(0)?.mainOffence).isEqualTo(true)
-    assertThat(convictions?.get(0)?.offences?.get(0)?.offenceId).isEqualTo("M2500000223")
-
-    assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.mainCategoryCode).isEqualTo("046")
-    assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.mainCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
-    assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.subCategoryCode).isEqualTo("00")
-    assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.subCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
-
-    assertThat(convictions?.get(0)?.sentence?.startDate).isEqualTo(LocalDate.of(2014, 8, 25))
+    @Test
+    fun `verify Offender Access returns unknown exception`() {
+      assertThrows<ExternalApiUnknownException> {
+        communityApiRestClient.verifyUserAccess("invalidNotKnow", "user1")
+      }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/OASysUpdateClientTest.kt
@@ -69,7 +69,7 @@ class OASysUpdateClientTest : IntegrationTest() {
     assertEquals(exception.client, ExternalService.ASSESSMENTS_API)
     assertEquals(
       exception.moreInfo,
-      "STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021."
+      listOf("STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021.")
     )
     assertEquals(exception.reason, ExceptionReason.OASYS_PERMISSION)
   }
@@ -126,7 +126,7 @@ class OASysUpdateClientTest : IntegrationTest() {
     assertEquals(exception.client, ExternalService.ASSESSMENTS_API)
     assertEquals(
       exception.moreInfo,
-      "STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021."
+      listOf("STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021.")
     )
     assertEquals(exception.reason, ExceptionReason.OASYS_PERMISSION)
   }
@@ -174,7 +174,9 @@ class OASysUpdateClientTest : IntegrationTest() {
     assertEquals(exception.client, ExternalService.ASSESSMENTS_API)
     assertEquals(
       exception.moreInfo,
-      "STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021."
+      listOf(
+        "STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021."
+      )
     )
     assertEquals(exception.reason, ExceptionReason.OASYS_PERMISSION)
   }
@@ -209,7 +211,7 @@ class OASysUpdateClientTest : IntegrationTest() {
     assertEquals(exception.client, ExternalService.ASSESSMENTS_API)
     assertEquals(
       exception.moreInfo,
-      "STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021."
+      listOf("STUART WHITLAM in Warwickshire is currently doing an assessment on this offender, created on 12/04/2021.")
     )
     assertEquals(exception.reason, ExceptionReason.OASYS_PERMISSION)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -80,6 +80,7 @@ class AssessmentServiceTest {
     fun `create new episode`() {
       val assessment: AssessmentEntity = mockk()
       every { assessment.assessmentUuid } returns assessmentUuid
+      every { offenderService.validateUserAccess(crn) } returns mockk()
       every { assessment.assessmentId } returns 0
       val episodeUuid1 = UUID.randomUUID()
       every {
@@ -182,7 +183,6 @@ class AssessmentServiceTest {
           )
         )
       )
-
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
 
       val episodeDto = assessmentsService.getCurrentAssessmentEpisode(assessmentUuid)
@@ -191,7 +191,6 @@ class AssessmentServiceTest {
 
     @Test
     fun `get current episode throws exception if assessment does not exist`() {
-
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns null
 
       assertThatThrownBy { assessmentsService.getCurrentAssessmentEpisode(assessmentUuid) }
@@ -201,7 +200,6 @@ class AssessmentServiceTest {
 
     @Test
     fun `get current episode throws exception if no current episode exists`() {
-
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns null
 
       assertThatThrownBy { assessmentsService.getCurrentAssessmentEpisode(assessmentUuid) }
@@ -235,7 +233,6 @@ class AssessmentServiceTest {
           )
         )
       )
-
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
 
       val result = assessmentsService.getCurrentAssessmentCodedAnswers(assessmentUuid)
@@ -281,7 +278,6 @@ class AssessmentServiceTest {
           ),
         )
       )
-
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
       val result = assessmentsService.getCurrentAssessmentCodedAnswers(assessmentUuid)
       assertThat(result.answers["Q1"]?.first()?.answerSchemaUuid).isEqualTo(answer1Uuid)
@@ -323,7 +319,6 @@ class AssessmentServiceTest {
           ),
         )
       )
-
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
 
       val result = assessmentsService.getCurrentAssessmentCodedAnswers(assessmentUuid)
@@ -349,7 +344,6 @@ class AssessmentServiceTest {
           )
         )
       )
-
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
       val result = assessmentsService.getCurrentAssessmentCodedAnswers(assessmentUuid)
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsServiceTest.kt
@@ -42,9 +42,10 @@ class RiskPredictorsServiceTest {
   private val subjectService: SubjectService = mockk()
   private val episodeRepository: EpisodeRepository = mockk()
   private val assessRisksAndNeedsApiRestClient: AssessRisksAndNeedsApiRestClient = mockk()
+  private val offenderService: OffenderService = mockk()
 
   private val predictorService =
-    RiskPredictorsService(assessmentSchemaService, subjectService, episodeRepository, assessRisksAndNeedsApiRestClient)
+    RiskPredictorsService(assessmentSchemaService, subjectService, episodeRepository, assessRisksAndNeedsApiRestClient, offenderService)
 
   private val testQuestion1 = QuestionSchemaEntity(
     questionSchemaId = 1,
@@ -542,6 +543,7 @@ class RiskPredictorsServiceTest {
     every {
       assessRisksAndNeedsApiRestClient.getRiskPredictors(any(), any(), final, episodeUuid)
     } returns null
+    every { offenderService.validateUserAccess(any()) } returns mockk()
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
@@ -165,6 +165,65 @@ class CommunityApiMockServer : WireMockServer(9096) {
     )
   }
 
+  fun stubGetUserAccess() {
+    stubFor(
+      WireMock.get(WireMock.urlPathMatching("/secure/offenders/crn/(?:X1|DX|CRN)[a-zA-Z0-9]*/user/([a-zA-Z0-9/-]*)/userAccess"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(laoSuccess)
+        )
+    )
+    stubFor(
+      WireMock.get(WireMock.urlPathMatching("/secure/offenders/crn/(OX[a-zA-Z0-9]*)/user/([a-zA-Z0-9/-]*)/userAccess"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(403)
+            .withBody(laoFailure)
+        )
+    )
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidNotFound/user/user1/userAccess"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(404)
+            .withBody("{\"status\":\"404\",\"developerMessage\":\"The offender is not found\"}")
+        )
+    )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidBadRequest/user/user1/userAccess"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(400)
+            .withBody("{\"status\":\"400\",\"developerMessage\":\"Invalid CRN invalidBadRequest\"}")
+        )
+    )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidUnauthorized/user/user1/userAccess"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(401)
+            .withBody("{\"status\":\"401\",\"developerMessage\":\"Not authorised\"}")
+        )
+    )
+
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/invalidNotKnow/user/user1/userAccess"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(422)
+            .withBody("{\"status\":\"422\",\"developerMessage\":\"unprocessable\"}")
+        )
+    )
+  }
+
   private fun mapToJson(dto: Any): String {
     return objectMapper.writeValueAsString(dto)
   }
@@ -382,6 +441,22 @@ class CommunityApiMockServer : WireMockServer(9096) {
       "first": true,
       "numberOfElements": 10,
       "empty": false
+    }
+  """.trimIndent()
+
+  private val laoSuccess = """{
+      "exclusionMessage": null,
+      "restrictionMessage": null,
+      "userExcluded": false,
+      "userRestricted": false
+    }
+  """.trimIndent()
+
+  private val laoFailure = """{
+      "exclusionMessage": "excluded",
+      "restrictionMessage": "restricted",
+      "userExcluded": true,
+      "userRestricted": true
     }
   """.trimIndent()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/IntegrationTest.kt
@@ -77,6 +77,7 @@ abstract class IntegrationTest {
     communityApiMockServer.resetAll()
     communityApiMockServer.stubGetOffender()
     communityApiMockServer.stubGetConvictions()
+    communityApiMockServer.stubGetUserAccess()
     assessmentApiMockServer.stubGetAssessment()
     assessRisksAndNeedsApiMockServer.resetAll()
   }
@@ -88,7 +89,7 @@ abstract class IntegrationTest {
 
   internal fun setAuthorisation(
     user: String = "offender-assessment-api",
-    roles: List<String> = listOf()
+    roles: List<String> = listOf("ROLE_PROBATION")
   ): (HttpHeaders) -> Unit {
     val token = jwtHelper.createJwt(
       subject = user,

--- a/src/test/resources/assessments/before-test.sql
+++ b/src/test/resources/assessments/before-test.sql
@@ -49,11 +49,22 @@ INSERT INTO hmppsassessmentsapi.subject (subject_uuid, name, pnc, crn, date_of_b
 INSERT INTO hmppsassessmentsapi.assessment  (assessment_uuid, subject_uuid, created_date) VALUES
 ('f9a07b3f-91b7-45a7-a5ca-2d98cf1147d8', 'a5e75a5c-5f1c-5f83-55b6-dd5ce1b75530', '2020-1-14 09:00');
 
+/* Invalid LAO rules assessment */
+INSERT INTO hmppsassessmentsapi.subject (subject_uuid, name, pnc, crn, date_of_birth, gender, created_date) VALUES
+('f9d551b4-602e-4dfa-bf4d-32d67a3914af', 'John Smith', 'dummy-pnc', 'OX1348', '2001-01-01', 'MALE', '2019-11-14 08:30');
+
+INSERT INTO hmppsassessmentsapi.assessment  (assessment_uuid, subject_uuid, created_date) VALUES
+('6e60784e-584e-4762-952d-d7288e31d4f4', 'f9d551b4-602e-4dfa-bf4d-32d67a3914af', '2020-1-14 09:00');
+
+INSERT INTO hmppsassessmentsapi.assessed_episode  (episode_uuid, user_id, assessment_schema_code, oasys_set_pk, created_date, end_date, change_reason, assessment_uuid, answers, offence_uuid) VALUES
+('3df6172f-a931-4fb9-a595-46868893b4ed', 'USER1', 'RSR', 1, '2021-01-01 00:00', null, 'More Change of Circs', '6e60784e-584e-4762-952d-d7288e31d4f4', '{}', '111111d1-1e0f-42f3-b5b5-f44b0e5bcb18');
+
+
 /* Episodes to complete */
 INSERT INTO hmppsassessmentsapi.subject (subject_uuid, name, oasys_offender_pk, pnc, crn, date_of_birth, gender, created_date) VALUES
 ('7bce2323-fefa-42eb-b622-ec65747aae56', 'John Smith', 1, 'dummy-pnc', 'X1345', '2001-01-01', 'MALE', '2019-11-14 08:30'),
-('1146f644-dfb9-4e6d-9446-1be089538480', 'John Smith', 12345, 'dummy-pnc', 'dummy-crn-1', '1928-08-01', 'MALE', '2019-11-14 08:30'),
-('f6023241-ba22-47e4-bc7d-f7adfde4276c', 'John Smith', 5, 'dummy-pnc', 'dummy-crn-2', '1928-08-01', 'MALE', '2019-11-14 08:30');
+('1146f644-dfb9-4e6d-9446-1be089538480', 'John Smith', 12345, 'dummy-pnc', 'X134698', '1928-08-01', 'MALE', '2019-11-14 08:30'),
+('f6023241-ba22-47e4-bc7d-f7adfde4276c', 'John Smith', 5, 'dummy-pnc', 'X134699', '1928-08-01', 'MALE', '2019-11-14 08:30');
 
 INSERT INTO hmppsassessmentsapi.assessment  (assessment_uuid, subject_uuid, created_date) VALUES
 ('e399ed1b-0e77-4c68-8bbc-d2f0befece84', '7bce2323-fefa-42eb-b622-ec65747aae56', '2020-1-14 09:00'),

--- a/src/test/resources/filteredReferenceData/before-test.sql
+++ b/src/test/resources/filteredReferenceData/before-test.sql
@@ -6,11 +6,11 @@ DELETE FROM hmppsassessmentsapi.subject WHERE true;
 
 /* Assessment with Episodes */
 INSERT INTO hmppsassessmentsapi.subject (subject_uuid, name, pnc, crn, date_of_birth, gender, created_date) VALUES
-('a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'John Smith', 'dummy-pnc', 'dummy-crn-1', '1928-08-01', 'MALE', '2019-11-14 08:30'),
-('bf1979c5-518a-4300-80f2-189981182e5f', 'John Smith', 'dummy-pnc', 'dummy-crn-2', '1928-08-01', 'MALE', '2019-11-14 08:30'),
-('f0c3c497-b0b8-4fe1-9749-2f686b3b1aa0', 'John Smith', 'dummy-pnc', 'dummy-crn-3', '1928-08-01', 'MALE', '2019-11-14 08:30'),
-('a2bb4345-beba-4806-b719-6cc4ae52ee43', 'John Smith', 'dummy-pnc', 'dummy-crn-4', '1928-08-01', 'MALE', '2019-11-14 08:30'),
-('36afe601-a2d9-4e32-b921-1c20fd0befef', 'John Smith', 'dummy-pnc', 'dummy-crn-5', '1928-08-01', 'MALE', '2019-11-14 08:30');
+('a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', 'John Smith', 'dummy-pnc', 'X13561', '1928-08-01', 'MALE', '2019-11-14 08:30'),
+('bf1979c5-518a-4300-80f2-189981182e5f', 'John Smith', 'dummy-pnc', 'X13562', '1928-08-01', 'MALE', '2019-11-14 08:30'),
+('f0c3c497-b0b8-4fe1-9749-2f686b3b1aa0', 'John Smith', 'dummy-pnc', 'X13563', '1928-08-01', 'MALE', '2019-11-14 08:30'),
+('a2bb4345-beba-4806-b719-6cc4ae52ee43', 'John Smith', 'dummy-pnc', 'X13564', '1928-08-01', 'MALE', '2019-11-14 08:30'),
+('36afe601-a2d9-4e32-b921-1c20fd0befef', 'John Smith', 'dummy-pnc', 'X13565', '1928-08-01', 'MALE', '2019-11-14 08:30');
 
 INSERT INTO hmppsassessmentsapi.assessment  (assessment_uuid, subject_uuid, created_date) VALUES
 ('2e020e78-a81c-407f-bc78-e5f284e237e5', 'a4e73a2c-3f1c-4f83-88b6-dd3ce1b78530', '2019-11-14 09:00'),

--- a/wiremock/mappings/community/DX12340A-userAccess-excluded.json
+++ b/wiremock/mappings/community/DX12340A-userAccess-excluded.json
@@ -1,0 +1,19 @@
+{
+  "id": "8909bfec-3dab-43e8-bdd2-70150d2d06c1",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/secure/offenders/crn/DX12340A/userAccess/user/SWITHLAM/userAccess"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "exclusionMessage": "User is excluded",
+      "restrictionMessage": null,
+      "userExcluded": true,
+      "userRestricted": false
+    }
+  }
+}

--- a/wiremock/mappings/community/DX12340A-userAccess-restricted.json
+++ b/wiremock/mappings/community/DX12340A-userAccess-restricted.json
@@ -1,0 +1,21 @@
+{
+  "id": "8909bfec-3dab-43e8-bdd2-70150d2d06c1",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/secure/offenders/crn/DX12340A/userAccess/user/SWITHLAM/userAccess"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "exclusionMessage": null,
+      "restrictionMessage": "Offender is restricted",
+      "userExcluded": false,
+      "userRestricted": true
+    }
+  }
+}
+
+

--- a/wiremock/mappings/community/DX12340A-userAccess.json
+++ b/wiremock/mappings/community/DX12340A-userAccess.json
@@ -1,0 +1,19 @@
+{
+  "id": "8909bfec-3dab-43e8-bdd2-70150d2d06c1",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/secure/offenders/crn/DX12340A/user/SWITHLAM/userAccess"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "exclusionMessage": null,
+      "restrictionMessage": null,
+      "userExcluded": false,
+      "userRestricted": false
+    }
+  }
+}


### PR DESCRIPTION
This adds Delius Limited Access Offender (LAO) validation to all endpoints which read or write data relating to an offender. Reference data remains unauthenticated.

To validate LAO access a CRN is required. Where a CRN is not present the check is skipped because CRN is not a required field for an assessment. In practice all currently created assessments will have a CRN because they are only created for Delius offenders. In future additional checks will need to added for NOMIS offenders once that functionality is required.

This could have been implemented as a Aspect used as an annotation as has been implemented for the OASys and Spring Security RBAC rules. This would have been difficult to implement because the CRN is sometimes a property of the object passed into the method or not present and so would require an additional call to get the CRN from the Assessment UUID.

