### PR TITLE
ARN 674 save gender field with subject entity when creating an assess…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -302,6 +302,7 @@ class AssessmentService(
         crn = crn,
         dateOfBirth = offender.dateOfBirth,
         createdDate = LocalDateTime.now(),
+        gender = offender.gender,
       )
     )
     val assessment = AssessmentEntity(subject = subjectEntity)


### PR DESCRIPTION
…ment

This PR aims to fix a bug where the gender field is not being set in the Assessments API subject table when starting an RSR assessment. 