### PR TITLE
Add audit service client

### DIFF
--- a/helm_deploy/hmpps-assessments-api/templates/_envs.tpl
+++ b/helm_deploy/hmpps-assessments-api/templates/_envs.tpl
@@ -91,6 +91,21 @@ env:
         name: {{ template "app.name" . }}
         key: API_CLIENT_SECRET
 
+    - name: AUDIT_BASE_URL
+      value: "{{ .Values.env.AUDIT_CLIENT_BASE_URL }}"
+
+    - name: AUDIT_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: {{ template "app.name" . }}
+          key: API_CLIENT_ID
+
+    - name: AUDIT_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: {{ template "app.name" . }}
+          key: API_CLIENT_SECRET
+
   - name: DATABASE_USERNAME
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/hmpps-assessments-api/templates/_envs.tpl
+++ b/helm_deploy/hmpps-assessments-api/templates/_envs.tpl
@@ -91,20 +91,20 @@ env:
         name: {{ template "app.name" . }}
         key: API_CLIENT_SECRET
 
-    - name: AUDIT_BASE_URL
-      value: "{{ .Values.env.AUDIT_CLIENT_BASE_URL }}"
+  - name: AUDIT_BASE_URL
+    value: "{{ .Values.env.AUDIT_CLIENT_BASE_URL }}"
 
-    - name: AUDIT_CLIENT_ID
-      valueFrom:
-        secretKeyRef:
-          name: {{ template "app.name" . }}
-          key: API_CLIENT_ID
+  - name: AUDIT_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "app.name" . }}
+        key: API_CLIENT_ID
 
-    - name: AUDIT_CLIENT_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: {{ template "app.name" . }}
-          key: API_CLIENT_SECRET
+  - name: AUDIT_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "app.name" . }}
+        key: API_CLIENT_SECRET
 
   - name: DATABASE_USERNAME
     valueFrom:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ env:
   COMMUNITY_API_BASE_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io/
   ASSESSMENT_API_BASE_URL: https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
   ASSESS_RISKS_AND_NEEDS_API_BASE_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/
+  AUDIT_BASE_URL: https://audit-api-dev.hmpps.service.justice.gov.uk
   SPRING_PROFILES_ACTIVE: "logstash,postgres,dev"
   STUB_RESTRICTED: "D002593"
   STUB_OFFSET: "200"

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentDto.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 data class AssessmentDto(
 
   @Schema(description = "Assessment UUID", example = "0e5e0848-6ab0-4b1b-a354-f7894913d8e4")
-  val assessmentUuid: UUID? = null,
+  val assessmentUuid: UUID,
 
   @Schema(description = "Created Date", example = "2020-01-02T16:00:00")
   val createdDate: LocalDateTime? = null,
@@ -27,13 +27,13 @@ data class AssessmentDto(
 
   companion object {
 
-    fun from(assessment: AssessmentEntity?): AssessmentDto {
+    fun from(assessment: AssessmentEntity): AssessmentDto {
       return AssessmentDto(
-        assessment?.assessmentUuid,
-        assessment?.createdDate,
-        assessment?.completedDate,
-        assessment?.subject.toSubjectDto(),
-        assessment?.let { AssessmentEpisodeDto.from(it.episodes) }
+        assessment.assessmentUuid,
+        assessment.createdDate,
+        assessment.completedDate,
+        assessment.subject.toSubjectDto(),
+        assessment.let { AssessmentEpisodeDto.from(it.episodes) }
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
@@ -13,7 +13,7 @@ data class AssessmentEpisodeDto(
   val episodeUuid: UUID? = null,
 
   @Schema(description = "Assessment UUID foreign key", example = "1234")
-  val assessmentUuid: UUID? = null,
+  val assessmentUuid: UUID,
 
   @Schema(description = "Associated OASys assessment ID (OASysSetPK)", example = "1234")
   val oasysAssessmentId: Long? = null,
@@ -64,7 +64,7 @@ data class AssessmentEpisodeDto(
     ): AssessmentEpisodeDto {
       return AssessmentEpisodeDto(
         episode.episodeUuid,
-        episode.assessment?.assessmentUuid,
+        episode.assessment.assessmentUuid,
         episode.oasysSetPk,
         episode.changeReason,
         episode.createdDate,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/config/WebClientConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/config/WebClientConfig.kt
@@ -34,6 +34,9 @@ class WebClientConfig {
   @Value("\${community-api.base-url}")
   private lateinit var communityApiBaseUrl: String
 
+  @Value("\${audit.base-url}")
+  private lateinit var auditBaseUrl: String
+
   @Value("\${feature.flags.disable-auth:false}")
   private val disableAuthentication = false
 
@@ -89,6 +92,15 @@ class WebClientConfig {
     return AuthenticatingRestClient(
       webClientFactory(communityApiBaseUrl, authorizedClientManager, bufferByteSize),
       "community-api-client",
+      disableAuthentication
+    )
+  }
+
+  @Bean
+  fun auditWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): AuthenticatingRestClient {
+    return AuthenticatingRestClient(
+      webClientFactory(auditBaseUrl, authorizedClientManager, bufferByteSize),
+      "audit-client",
       disableAuthentication
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AssessmentEpisodeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AssessmentEpisodeEntity.kt
@@ -38,7 +38,7 @@ data class AssessmentEpisodeEntity(
 
   @ManyToOne
   @JoinColumn(name = "assessment_uuid", referencedColumnName = "assessment_uuid")
-  val assessment: AssessmentEntity? = null,
+  val assessment: AssessmentEntity,
 
   @Column(name = "assessment_schema_code")
   @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AuthorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AuthorEntity.kt
@@ -11,7 +11,7 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "author", schema = "hmppsassessmentsapi")
-class AuthorEntity(
+data class AuthorEntity(
   @Id
   @Column(name = "author_id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AuditRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/AuditRestClient.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.assessments.restclient
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.RiskPredictorsDto
+import uk.gov.justice.digital.assessments.restclient.audit.AuditEvent
+import uk.gov.justice.digital.assessments.services.exceptions.AuditFailureException
+
+@Component
+class AuditRestClient {
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Autowired
+  @Qualifier("auditWebClient")
+  internal lateinit var webClient: AuthenticatingRestClient
+
+  @Value("\${audit.base-url}")
+  internal lateinit var auditPathTemplate: String
+
+  fun createAuditEvent(
+    auditEvent: AuditEvent
+  ) {
+    AssessRisksAndNeedsApiRestClient.log.info("Submitting audit event ${auditEvent.what} for CRN ${auditEvent.details.crn}")
+    val path = "$auditPathTemplate/audit"
+    webClient.post(path, auditEvent)
+      .retrieve()
+      .bodyToMono(RiskPredictorsDto::class.java)
+      .onErrorResume {
+        Mono.error(
+          AuditFailureException(
+            "Failed to Audit event ${auditEvent.what} " +
+              "for CRN: ${auditEvent.details.crn} by user ${auditEvent.who} for reason ${it.message}"
+          )
+        )
+      }
+      .block().also { log.info("Audited event ${auditEvent.what} for CRN ${auditEvent.details.crn}") }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/audit/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/audit/AuditEvent.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.assessments.restclient.audit
+
+import uk.gov.justice.digital.assessments.jpa.entities.assessments.AuthorEntity
+import java.time.Instant
+import java.util.UUID
+
+data class AuditEvent(
+  val what: String,
+  val `when`: Instant,
+  val who: String?,
+  val service: String?,
+  val details: AuditDetail
+)
+
+data class AuditDetail(
+  val crn: String?,
+  val assessmentUuid: UUID,
+  val episodeUuid: UUID?,
+  val author: AuthorEntity?,
+  val additionalDetails: Any?
+)
+
+enum class AuditType {
+  ARN_ASSESSMENT_CREATED,
+  ARN_ASSESSMENT_UPDATED,
+  ARN_ASSESSMENT_CLOSED,
+  ARN_ASSESSMENT_REASSIGNED,
+  ARN_ASSESSMENT_COMPLETED
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AuditService.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.assessments.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.assessments.jpa.entities.assessments.AuthorEntity
+import uk.gov.justice.digital.assessments.restclient.AuditRestClient
+import uk.gov.justice.digital.assessments.restclient.audit.AuditDetail
+import uk.gov.justice.digital.assessments.restclient.audit.AuditEvent
+import uk.gov.justice.digital.assessments.restclient.audit.AuditType
+import uk.gov.justice.digital.assessments.services.exceptions.AuditFailureException
+import uk.gov.justice.digital.assessments.utils.RequestData
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class AuditService(
+  private val auditClient: AuditRestClient,
+  @Value("\${spring.application.name}")
+  private val serviceName: String,
+  private val mapper: ObjectMapper,
+  private val clock: Clock = Clock.systemUTC()
+) {
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun createAuditEvent(auditType: AuditType, assessmentUUID: UUID, episodeUUID: UUID?, crn: String?, author: AuthorEntity?, additionalDetails: Any? = null) {
+
+    val auditEvent = AuditEvent(
+      what = auditType.name,
+      who = RequestData.getUserName(),
+      service = serviceName,
+      `when` = Instant.now(clock),
+      details = AuditDetail(
+        crn = crn,
+        assessmentUuid = assessmentUUID,
+        episodeUuid = episodeUUID,
+        author = author,
+        if (additionalDetails != null) mapper.writeValueAsString(additionalDetails) else null
+      )
+    )
+    // Initially log audit failures as errors,
+    // so they can be alerted on but do not prevent the user completing the transaction
+    try {
+      auditClient.createAuditEvent(auditEvent)
+    } catch (e: AuditFailureException) {
+      log.error(e.message)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
@@ -90,7 +90,7 @@ class EpisodeService(
   }
 
   private fun loadFromDelius(episode: AssessmentEpisodeEntity, sourceEndpoint: String?): String? {
-    val crn = episode?.assessment?.subject?.crn
+    val crn = episode.assessment.subject?.crn
       ?: throw CrnIsMandatoryException("Crn not found for episode ${episode.episodeUuid}")
     val externalSourceEndpoint = sourceEndpoint
       ?: throw ExternalSourceEndpointIsMandatoryException("External source endpoint is mandatory for episode ${episode.episodeUuid}")

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentUpdateService.kt
@@ -30,7 +30,7 @@ class OasysAssessmentUpdateService(
     episode: AssessmentEpisodeEntity,
     updatedEpisodeAnswers: Answers,
   ): AssessmentEpisodeUpdateErrors {
-    val offenderPk = episode.assessment?.subject?.oasysOffenderPk
+    val offenderPk = episode.assessment.subject?.oasysOffenderPk
     if (episode.oasysSetPk == null || offenderPk == null) {
       val errorMessage =
         "Unable to update OASys Assessment with keys type: ${episode.assessmentSchemaCode} oasysSet: ${episode.oasysSetPk} offenderPk: $offenderPk, values cant be null"

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
@@ -40,7 +40,7 @@ class RiskPredictorsService(
   fun getPredictorResults(episodeUuid: UUID, final: Boolean = false): List<PredictorScoresDto> {
     val episode = episodeRepository.findByEpisodeUuid(episodeUuid)
       ?: throw EntityNotFoundException("Episode with $episodeUuid not found")
-    episode.assessment?.subject?.crn?.let { offenderService.validateUserAccess(it) }
+    episode.assessment.subject?.crn?.let { offenderService.validateUserAccess(it) }
     return getPredictorResults(episode)
   }
 
@@ -131,8 +131,7 @@ class RiskPredictorsService(
   }
 
   private fun getEpisodeAssessmentUuid(episode: AssessmentEpisodeEntity): UUID {
-    return episode.assessment?.assessmentUuid
-      ?: throw EntityNotFoundException("Episode ${episode.episodeUuid} is not associated with an assessment")
+    return episode.assessment.assessmentUuid
   }
 
   private fun getDynamicScoringOffences(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
@@ -22,6 +22,7 @@ class PredictorCalculationException(msg: String?) : RuntimeException(msg)
 class MultipleExternalSourcesException(msg: String?) : RuntimeException(msg)
 class CrnIsMandatoryException(msg: String?) : RuntimeException(msg)
 class ExternalSourceEndpointIsMandatoryException(msg: String?) : RuntimeException(msg)
+class AuditFailureException(msg: String?) : RuntimeException(msg)
 
 class OASysUserPermissionException(
   msg: String?,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,13 @@ spring:
             client-authentication-method: basic
             authorization-grant-type: client_credentials
             provider: oauth-service
+          audit-client:
+            client-name: audit-client
+            client-id: ${audit-client-id:community-api-client}
+            client-secret: ${audit-client-secret:clientsecret}
+            client-authentication-method: basic
+            authorization-grant-type: client_credentials
+            provider: oauth-service
         provider:
           oauth-service:
             token-uri: ${oauth.endpoint.url:http://localhost:9090/auth}/oauth/token
@@ -132,6 +139,9 @@ assessment-update-api:
   base-url: http://localhost:9080
 
 community-api:
+  base-url: http://localhost:9080
+
+audit:
   base-url: http://localhost:9080
 
 assessment-api:

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AssessmentEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/jpa/entities/AssessmentEntityTest.kt
@@ -59,7 +59,8 @@ class AssessmentEntityTest {
           changeReason = "Change of Circs",
           createdDate = LocalDateTime.now(),
           assessmentSchemaCode = AssessmentSchemaCode.ROSH,
-          author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name")
+          author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+          assessment = AssessmentEntity()
         )
       )
     )
@@ -92,6 +93,7 @@ class AssessmentEntityTest {
           createdDate = LocalDateTime.now(),
           assessmentSchemaCode = AssessmentSchemaCode.ROSH,
           author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+          assessment = AssessmentEntity()
         )
       )
     )
@@ -112,6 +114,7 @@ class AssessmentEntityTest {
           endDate = LocalDateTime.now().minusDays(1),
           assessmentSchemaCode = AssessmentSchemaCode.ROSH,
           author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+          assessment = AssessmentEntity()
         )
       )
     )

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AuditClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AuditClientTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.assessments.restclient
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.assessments.jpa.entities.assessments.AuthorEntity
+import uk.gov.justice.digital.assessments.restclient.audit.AuditDetail
+import uk.gov.justice.digital.assessments.restclient.audit.AuditEvent
+import uk.gov.justice.digital.assessments.restclient.audit.AuditType
+import uk.gov.justice.digital.assessments.services.exceptions.AuditFailureException
+import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import java.time.Instant
+import java.util.UUID
+
+class AuditClientTest : IntegrationTest() {
+  @Autowired
+  internal lateinit var auditClient: AuditRestClient
+
+  val auditEvent = AuditEvent(
+    what = AuditType.ARN_ASSESSMENT_CREATED.name,
+    who = "user@justice.gov.uk",
+    service = "hmpps-assessments-api",
+    `when` = Instant.now(),
+    details = AuditDetail(
+      "X123456C",
+      UUID.randomUUID(),
+      UUID.randomUUID(),
+      AuthorEntity(
+        1,
+        UUID.randomUUID(),
+        "user id",
+        "AUser",
+        "DELIUS",
+        "Full Name"
+      ),
+      null
+    )
+  )
+
+  @Test
+  fun `submit new audit event`() {
+
+    assertDoesNotThrow {
+      auditClient.createAuditEvent(auditEvent)
+    }
+  }
+
+  @Test
+  fun `throws exception when submit new audit event fails`() {
+
+    assertThrows<AuditFailureException> {
+      auditClient.createAuditEvent(auditEvent.copy(who = "error-user@justice.gov.uk"))
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.assessments.services
 
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -22,6 +24,7 @@ import uk.gov.justice.digital.assessments.jpa.entities.refdata.QuestionSchemaEnt
 import uk.gov.justice.digital.assessments.jpa.repositories.assessments.AssessmentRepository
 import uk.gov.justice.digital.assessments.jpa.repositories.assessments.SubjectRepository
 import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
+import uk.gov.justice.digital.assessments.restclient.audit.AuditType
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -38,6 +41,7 @@ class AssessmentServiceTest {
   private val episodeService: EpisodeService = mockk()
   private val offenderService: OffenderService = mockk()
   private val oasysAssessmentUpdateService: OasysAssessmentUpdateService = mockk()
+  private val auditService: AuditService = mockk()
 
   private val assessmentsService = AssessmentService(
     assessmentRepository,
@@ -47,7 +51,8 @@ class AssessmentServiceTest {
     episodeService,
     courtCaseRestClient,
     oasysAssessmentUpdateService,
-    offenderService
+    offenderService,
+    auditService
   )
 
   private val assessmentUuid = UUID.randomUUID()
@@ -82,6 +87,7 @@ class AssessmentServiceTest {
     @Test
     fun `create new episode`() {
       val assessment: AssessmentEntity = mockk()
+      justRun { auditService.createAuditEvent(any(), any(), any(), any(), any(), any()) }
       every { assessment.assessmentUuid } returns assessmentUuid
       every { offenderService.validateUserAccess(crn) } returns mockk()
       every { assessment.assessmentId } returns 0
@@ -129,6 +135,17 @@ class AssessmentServiceTest {
 
       assertThat(episodeDto.assessmentUuid).isEqualTo(assessmentUuid)
       assertThat(episodeDto.episodeUuid).isEqualTo(episodeUuid1)
+
+      verify(exactly = 1) {
+        auditService.createAuditEvent(
+          AuditType.ARN_ASSESSMENT_CREATED,
+          assessmentUuid,
+          episodeDto.episodeUuid,
+          crn,
+          any(),
+          any()
+        )
+      }
     }
 
     @Test
@@ -144,6 +161,7 @@ class AssessmentServiceTest {
             author = AuthorEntity(
               userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
           AssessmentEpisodeEntity(
             episodeId = episodeId2,
@@ -156,6 +174,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           )
         )
       )
@@ -194,6 +213,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
           AssessmentEpisodeEntity(
             episodeId = episodeId2,
@@ -207,6 +227,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           )
         )
       )
@@ -257,6 +278,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
           AssessmentEpisodeEntity(
             episodeId = episodeId2,
@@ -269,6 +291,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           )
         )
       )
@@ -302,6 +325,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
           AssessmentEpisodeEntity(
             episodeId = episodeId3,
@@ -317,6 +341,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
           AssessmentEpisodeEntity(
             episodeId = episodeId2,
@@ -332,6 +357,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
         )
       )
@@ -361,6 +387,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
           AssessmentEpisodeEntity(
             episodeId = episodeId3,
@@ -376,6 +403,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
           AssessmentEpisodeEntity(
             episodeId = episodeId2,
@@ -391,6 +419,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           ),
         )
       )
@@ -422,6 +451,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           )
         )
       )
@@ -453,6 +483,7 @@ class AssessmentServiceTest {
               userAuthSource = "source",
               userFullName = "full name"
             ),
+            assessment = AssessmentEntity()
           )
         )
       )

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.assessments.services
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.security.core.GrantedAuthority
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Scor
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
 import uk.gov.justice.digital.assessments.services.dto.ScoreType
 import uk.gov.justice.digital.assessments.testutils.IntegrationTest
+import uk.gov.justice.digital.assessments.utils.RequestData
 import java.math.BigDecimal
 import java.util.UUID
 
@@ -54,6 +56,11 @@ class AssessmentUpdateServiceITTest() : IntegrationTest() {
       .build()
     val authorities: Collection<GrantedAuthority> = AuthorityUtils.createAuthorityList("SCOPE_read")
     SecurityContextHolder.getContext().authentication = JwtAuthenticationToken(jwt, authorities)
+    MDC.put(RequestData.USER_AREA_HEADER, "WWS")
+    MDC.put(RequestData.USER_ID_HEADER, "1")
+    MDC.put(RequestData.USER_NAME_HEADER, "SWITHLAM")
+    MDC.put(RequestData.USER_FULL_NAME_HEADER, "Stuart Withlam")
+    MDC.put(RequestData.USER_AUTH_SOURCE_HEADER, "delius")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTablesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTablesTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode
+import uk.gov.justice.digital.assessments.jpa.entities.assessments.AssessmentEntity
 import uk.gov.justice.digital.assessments.jpa.entities.assessments.AssessmentEpisodeEntity
 import uk.gov.justice.digital.assessments.jpa.entities.assessments.AuthorEntity
 import uk.gov.justice.digital.assessments.jpa.entities.refdata.OasysAssessmentType
@@ -30,6 +31,7 @@ class AssessmentUpdateServiceTablesTest {
   private val oasysAssessmentUpdateService: OasysAssessmentUpdateService = mockk()
   private val assessmentService: AssessmentService = mockk()
   private val authorService: AuthorService = mockk()
+  private val auditService: AuditService = mockk()
 
   private val assessmentUpdateService = AssessmentUpdateService(
     assessmentRepository,
@@ -38,7 +40,8 @@ class AssessmentUpdateServiceTablesTest {
     riskPredictorsService,
     oasysAssessmentUpdateService,
     assessmentService,
-    authorService
+    authorService,
+    auditService
   )
 
   private val tableName = "test_table"
@@ -65,6 +68,7 @@ class AssessmentUpdateServiceTablesTest {
     episodeUuid = episodeUuid,
     assessmentSchemaCode = AssessmentSchemaCode.ROSH,
     author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+    assessment = AssessmentEntity()
   )
 
   @BeforeEach
@@ -180,6 +184,7 @@ class AssessmentUpdateServiceTablesTest {
         )
       ),
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity()
     )
 
     val requestBody = UpdateAssessmentEpisodeDto(
@@ -217,6 +222,7 @@ class AssessmentUpdateServiceTablesTest {
       episodeUuid = episodeUuid,
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity(),
       tables = mutableMapOf(
         tableName to mutableListOf(
           mapOf(
@@ -261,6 +267,7 @@ class AssessmentUpdateServiceTablesTest {
       episodeUuid = episodeUuid,
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity(),
       tables = mutableMapOf(
         tableName to mutableListOf(
           mapOf(
@@ -308,6 +315,7 @@ class AssessmentUpdateServiceTablesTest {
       episodeUuid = episodeUuid,
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity(),
       tables = mutableMapOf(
         tableName to mutableListOf(
           mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AuditServiceTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.assessments.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.assessments.jpa.entities.assessments.AuthorEntity
+import uk.gov.justice.digital.assessments.restclient.AuditRestClient
+import uk.gov.justice.digital.assessments.restclient.audit.AuditDetail
+import uk.gov.justice.digital.assessments.restclient.audit.AuditEvent
+import uk.gov.justice.digital.assessments.restclient.audit.AuditType
+import uk.gov.justice.digital.assessments.services.exceptions.AuditFailureException
+import uk.gov.justice.digital.assessments.utils.RequestData
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+@DisplayName("Audit Service Tests")
+class AuditServiceTest {
+
+  private val auditRestClient: AuditRestClient = mockk()
+  private val objectMapper = ObjectMapper()
+  private val clock: Clock = Clock.fixed(Instant.ofEpochSecond(1635419271), ZoneId.systemDefault())
+  private val auditService: AuditService = AuditService(auditRestClient, "hmpps-assessments-api", objectMapper, clock)
+  private val serviceName = "hmpps-assessments-api"
+  private val crn = "X123456C"
+  private val assessmentUUID = UUID.randomUUID()
+  private val episodeUUID = UUID.randomUUID()
+  private val authorUUID = UUID.randomUUID()
+  private val auditType = AuditType.ARN_ASSESSMENT_CREATED
+  private val actualAuditEvent = slot<AuditEvent>()
+  val authorEntity = AuthorEntity(userId = "user id", userName = "user name", authorUuid = authorUUID)
+
+  @Test
+  fun `submits audit event`() {
+    mockkObject(RequestData) {
+      every { RequestData.getUserName() } returns "user name"
+
+      val expectedAuditEvent = AuditEvent(
+        what = auditType.name,
+        who = RequestData.getUserName(),
+        service = serviceName,
+        `when` = Instant.now(clock),
+        details = AuditDetail(
+          crn = crn,
+          assessmentUuid = assessmentUUID,
+          episodeUuid = episodeUUID,
+          author = authorEntity,
+          null
+        )
+      )
+      justRun { auditRestClient.createAuditEvent(capture(actualAuditEvent)) }
+      auditService.createAuditEvent(auditType, assessmentUUID, episodeUUID, crn, authorEntity, null)
+      assertThat(expectedAuditEvent).isEqualTo(actualAuditEvent.captured)
+    }
+  }
+
+  @Test
+  fun `submits audit event with additional detail`() {
+    mockkObject(RequestData) {
+      every { RequestData.getUserName() } returns "user name"
+
+      val expectedAuditEvent = AuditEvent(
+        what = auditType.name,
+        who = RequestData.getUserName(),
+        service = serviceName,
+        `when` = Instant.now(clock),
+        details = AuditDetail(
+          crn = crn,
+          assessmentUuid = assessmentUUID,
+          episodeUuid = episodeUUID,
+          author = authorEntity,
+          additionalDetails = """{"allocatedFrom":"user 1"}"""
+        )
+      )
+
+      justRun { auditRestClient.createAuditEvent(capture(actualAuditEvent)) }
+      auditService.createAuditEvent(auditType, assessmentUUID, episodeUUID, crn, authorEntity, mapOf("allocatedFrom" to "user 1"))
+      assertThat(expectedAuditEvent).isEqualTo(actualAuditEvent.captured)
+    }
+  }
+
+  @Test
+  fun `submit audit event does not fail on error`() {
+    mockkObject(RequestData) {
+      every { RequestData.getUserName() } returns "user name"
+
+      val expectedAuditEvent = AuditEvent(
+        what = auditType.name,
+        who = RequestData.getUserName(),
+        service = serviceName,
+        `when` = Instant.now(clock),
+        details = AuditDetail(
+          crn = crn,
+          assessmentUuid = assessmentUUID,
+          episodeUuid = episodeUUID,
+          author = authorEntity,
+          null
+        )
+      )
+      every { auditRestClient.createAuditEvent(capture(actualAuditEvent)) } throws AuditFailureException("An error occurred")
+      assertDoesNotThrow {
+        auditService.createAuditEvent(auditType, assessmentUUID, episodeUUID, crn, authorEntity, null)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentServiceTest.kt
@@ -32,6 +32,7 @@ class OasysAssessmentServiceTest {
       endDate = LocalDateTime.now(),
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity()
     )
     val episode1 = AssessmentEpisodeEntity(
       episodeId = 456,
@@ -40,6 +41,7 @@ class OasysAssessmentServiceTest {
       endDate = LocalDateTime.now().minusDays(1),
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity()
     )
     val assessment = AssessmentEntity(
       assessmentId = 1232,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OasysAssessmentUpdateServiceTest.kt
@@ -103,6 +103,7 @@ class OasysAssessmentUpdateServiceTest() {
       createdDate = LocalDateTime.now(),
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity()
     )
     val update = mapOf(questionCode1 to listOf("YES"))
 
@@ -162,6 +163,7 @@ class OasysAssessmentUpdateServiceTest() {
       episodeId = 128,
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+      assessment = AssessmentEntity()
     )
     val update = UpdateAssessmentEpisodeDto(answers = mapOf(questionCode1 to listOf("Updated")))
     val updateAssessmentResponse =
@@ -176,7 +178,7 @@ class OasysAssessmentUpdateServiceTest() {
       episodeId = 128,
       assessmentSchemaCode = AssessmentSchemaCode.ROSH,
       author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
-
+      assessment = AssessmentEntity()
     )
     val completeAssessmentResponse =
       oasysAssessmentUpdateService.completeOASysAssessment(assessmentEpisode, null)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/ReferenceDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/ReferenceDataServiceTest.kt
@@ -36,6 +36,7 @@ private val episode = AssessmentEpisodeEntity(
   assessmentSchemaCode = AssessmentSchemaCode.ROSH,
   createdDate = LocalDateTime.now(),
   author = AuthorEntity(userId = "1", userName = "USER", userAuthSource = "source", userFullName = "full name"),
+  assessment = AssessmentEntity()
 )
 private val assessment = AssessmentEntity(episodes = mutableListOf(episode))
 private val referenceDataElement = RefElementDto("code", "short description", "long description")

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/AuditMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/AuditMockServer.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.assessments.testutils
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.http.HttpHeader
+import com.github.tomakehurst.wiremock.http.HttpHeaders
+
+class AuditMockServer : WireMockServer(9008) {
+
+  private val objectMapper: ObjectMapper = jacksonObjectMapper().registerModules(JavaTimeModule())
+
+  fun stubAuditEvents() {
+    stubFor(
+      WireMock.post(WireMock.urlEqualTo("/audit")).atPriority(1)
+        .withRequestBody(WireMock.equalToJson("{\"who\": \"error-user@justice.gov.uk\"}", true, true))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(500)
+            .withBody(auditError)
+        )
+    )
+
+    stubFor(
+      WireMock.post(WireMock.urlEqualTo("/audit")).atPriority(5)
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(201)
+        )
+    )
+  }
+
+  private val auditError = """{
+      "status": 500,
+      "errorCode": 0,
+      "userMessage": "string",
+      "developerMessage": "string",
+      "moreInfo": "string"
+  }
+  """.trimIndent()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/IntegrationTest.kt
@@ -40,6 +40,7 @@ abstract class IntegrationTest {
     internal val communityApiMockServer = CommunityApiMockServer()
     internal val assessmentApiMockServer = AssessmentApiMockServer()
     internal val assessRisksAndNeedsApiMockServer = AssessRisksAndNeedsApiMockServer()
+    internal val auditApiMockServer = AuditMockServer()
 
     @BeforeAll
     @JvmStatic
@@ -49,6 +50,7 @@ abstract class IntegrationTest {
       communityApiMockServer.start()
       assessmentApiMockServer.start()
       assessRisksAndNeedsApiMockServer.start()
+      auditApiMockServer.start()
     }
 
     @AfterAll
@@ -59,6 +61,7 @@ abstract class IntegrationTest {
       communityApiMockServer.stop()
       assessmentApiMockServer.stop()
       assessRisksAndNeedsApiMockServer.stop()
+      auditApiMockServer.stop()
     }
   }
 
@@ -83,6 +86,7 @@ abstract class IntegrationTest {
     communityApiMockServer.stubGetUserAccess()
     assessmentApiMockServer.stubGetAssessment()
     assessRisksAndNeedsApiMockServer.resetAll()
+    auditApiMockServer.stubAuditEvents()
   }
 
   @AfterEach

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -46,3 +46,6 @@ community-api:
 
 assess-risks-and-needs-api:
   base-url: http://localhost:9007
+
+audit:
+  base-url: http://localhost:9008

--- a/wiremock/mappings/audit/auditSuccess.json
+++ b/wiremock/mappings/audit/auditSuccess.json
@@ -1,0 +1,17 @@
+{
+  "id": "4e842519-78b0-4449-b2b5-535ee1b81543",
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/audit",
+    "bodyPatterns" : [ {
+      "equalToJson" : "",
+      "ignoreExtraElements" : true
+    } ]
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200
+    }
+}


### PR DESCRIPTION
This adds an audit client for the DPS Audit service and audits:
- New assessments/episodes
- updates to episodes
- change of author

Additional changes made to support auditing:
- No longer allow null assessments on an episode
- Make some episode and assessment fields non nullable