### PR TITLE
Create endpoint to fetch offender registrations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/RegistrationsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/RegistrationsDto.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.assessments.api
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistration
+
+// TODO: populate this list
+val flagsToInclude = listOf<String>("IRMO")
+
+data class RegistrationsDto(
+  @Schema(description = "Mappa level and category", example = "{}")
+  val mappa: Mappa? = null,
+
+  @Schema(description = "Flags", example = "[]")
+  val flags: List<Flag> = emptyList(),
+) {
+  companion object {
+    fun from(registrations: List<CommunityRegistration>): RegistrationsDto {
+      val mappa = registrations.firstOrNull { it.type.code == "MAPP" }
+
+      return RegistrationsDto(
+        mappa?.let { Mappa(it.registerLevel?.code, it.registerLevel?.description, it.registerCategory?.code, it.registerCategory?.description) },
+        registrations
+          .filter { it.active && flagsToInclude.contains(it.type.code) }
+          .map { Flag(it.type.code, it.type.description, it.riskColour) }
+      )
+    }
+  }
+}
+
+class Flag(
+  val code: String,
+  val description: String,
+  val colour: String,
+)
+
+class Mappa(
+  val level: String?,
+  val levelDescription: String?,
+  val category: String?,
+  val categoryDescription: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/RegistrationsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/RegistrationsDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.assessments.api
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistration
+import java.time.LocalDate
 
 // TODO: populate this list
 val flagsToInclude = listOf<String>("IRMO")
@@ -18,7 +19,7 @@ data class RegistrationsDto(
       val mappa = registrations.firstOrNull { it.type.code == "MAPP" }
 
       return RegistrationsDto(
-        mappa?.let { Mappa(it.registerLevel?.code, it.registerLevel?.description, it.registerCategory?.code, it.registerCategory?.description) },
+        mappa?.let { Mappa(it.registerLevel?.code, it.registerLevel?.description, it.registerCategory?.code, it.registerCategory?.description, it.startDate) },
         registrations
           .filter { it.active && flagsToInclude.contains(it.type.code) }
           .map { Flag(it.type.code, it.type.description, it.riskColour) }
@@ -38,4 +39,5 @@ class Mappa(
   val levelDescription: String?,
   val category: String?,
   val categoryDescription: String?,
+  val startDate: LocalDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/RegistrationsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/RegistrationsDto.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegis
 import java.time.LocalDate
 
 // TODO: populate this list
-val flagsToInclude = listOf<String>("IRMO")
+val flagsToNotInclude = listOf("MAPP")
 
 data class RegistrationsDto(
   @Schema(description = "Mappa level and category", example = "{}")
@@ -21,7 +21,7 @@ data class RegistrationsDto(
       return RegistrationsDto(
         mappa?.let { Mappa(it.registerLevel?.code, it.registerLevel?.description, it.registerCategory?.code, it.registerCategory?.description, it.startDate) },
         registrations
-          .filter { it.active && flagsToInclude.contains(it.type.code) }
+          .filter { it.active && !flagsToNotInclude.contains(it.type.code) }
           .map { Flag(it.type.code, it.type.description, it.riskColour) }
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/RisksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/RisksController.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.assessments.controllers
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.assessments.api.RegistrationsDto
+import uk.gov.justice.digital.assessments.services.RisksService
+
+@RestController
+class RisksController(
+  val risksService: RisksService,
+) {
+  @RequestMapping(path = ["/assessments/{crn}/registrations"], method = [RequestMethod.GET])
+  @Operation(description = "Get Mappa and risk flags for the assessment")
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "401", description = "Invalid JWT Token"),
+      ApiResponse(responseCode = "200", description = "OK")
+    ]
+  )
+  @PreAuthorize("hasRole('ROLE_PROBATION')")
+  fun getRegistrationsForAssessment(
+    @Parameter(
+      description = "CRN",
+      required = true
+    ) @PathVariable crn: String
+  ): RegistrationsDto {
+    return risksService.getRegistrationsForAssessment(crn)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityConvictionDto
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityOffenderDto
+import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistrations
 import uk.gov.justice.digital.assessments.restclient.communityapi.UserAccessResponse
 import uk.gov.justice.digital.assessments.services.exceptions.ExceptionReason
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiForbiddenException
@@ -83,6 +84,32 @@ class CommunityApiRestClient {
         )
       }
       .bodyToMono(object : ParameterizedTypeReference<List<CommunityConvictionDto>>() {})
+      .block()
+  }
+
+  fun getRegistrations(crn: String): CommunityRegistrations? {
+    log.info("Client retrieving registrations for crn: $crn")
+    val path = "secure/offenders/crn/$crn/registrations"
+    return webClient
+      .get(path)
+      .retrieve()
+      .onStatus(HttpStatus::is4xxClientError) {
+        handle4xxError(
+          it,
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
+      .onStatus(HttpStatus::is5xxServerError) {
+        handle5xxError(
+          "Failed to retrieve registrations for crn: $crn",
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
+      .bodyToMono(object : ParameterizedTypeReference<CommunityRegistrations>() {})
       .block()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/CommunityRegistrations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/CommunityRegistrations.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.assessments.restclient.communityapi
+
+data class CommunityRegistrations(
+  val registrations: Collection<CommunityRegistration> = emptyList()
+)
+
+data class CommunityRegistration(
+  val active: Boolean,
+  val warnUser: Boolean,
+  val riskColour: String,
+  val registerCategory: CommunityRegistrationElement? = null,
+  val registerLevel: CommunityRegistrationElement? = null,
+  val type: CommunityRegistrationElement,
+)
+
+class CommunityRegistrationElement(
+  val code: String,
+  val description: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/CommunityRegistrations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/CommunityRegistrations.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.assessments.restclient.communityapi
 
+import java.time.LocalDate
+
 data class CommunityRegistrations(
   val registrations: Collection<CommunityRegistration> = emptyList()
 )
@@ -11,6 +13,7 @@ data class CommunityRegistration(
   val registerCategory: CommunityRegistrationElement? = null,
   val registerLevel: CommunityRegistrationElement? = null,
   val type: CommunityRegistrationElement,
+  val startDate: LocalDate,
 )
 
 class CommunityRegistrationElement(

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/RisksService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/RisksService.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.assessments.services
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.assessments.api.RegistrationsDto
+import uk.gov.justice.digital.assessments.restclient.CommunityApiRestClient
+
+@Service
+class RisksService(
+  private val communityApiRestClient: CommunityApiRestClient,
+) {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getRegistrationsForAssessment(crn: String): RegistrationsDto {
+    log.info("Getting registrations for crn: $crn")
+    val response = communityApiRestClient.getRegistrations(crn)
+      ?: throw Exception("Failed to get registrations for assessments")
+
+    return RegistrationsDto.from(response.registrations.toList())
+  }
+}

--- a/src/main/resources/db/migration/refdata/V1_8__external_sources_mappings.sql
+++ b/src/main/resources/db/migration/refdata/V1_8__external_sources_mappings.sql
@@ -80,10 +80,5 @@ VALUES
 ('d48a7841-8398-4964-8fa9-30b932191296', 'upw_caring_commitments', 'UPW', 'DELIUS', '$.personalCircumstances[?(@.personalCircumstanceType.code==''I'')].personalCircumstanceSubType.description', 'yesno', 'secure/offenders/crn/$crn/personalCircumstances'),
 ('e2765bb6-5d2a-47c5-babb-d8cbd9842c26', 'upw_caring_commitments_details', 'UPW', 'DELIUS', '$.personalCircumstances[?(@.personalCircumstanceType.code==''I'')].notes', null, 'secure/offenders/crn/$crn/personalCircumstances'),
 ('cdd2f423-7805-4775-9ca2-ea23bf268365', 'upw_reading_writing_difficulties', 'UPW', 'DELIUS', '$.personalCircumstances[?(@.personalCircumstanceType.code==''G'')].personalCircumstanceSubType.description', 'yesno', 'secure/offenders/crn/$crn/personalCircumstances'),
-('6a65d799-3796-497c-b09d-8dab9822fb6c', 'upw_reading_writing_difficulties_details', 'UPW', 'DELIUS', '$.personalCircumstances[?(@.personalCircumstanceType.code==''G'')].notes', null, 'secure/offenders/crn/$crn/personalCircumstances'),
-
-('9cad42e2-be52-4efb-ac2e-98f2872eed6d', 'mappa_nominal_description', 'UPW', 'DELIUS', '$.registrations[?(@.type.code==''MAPP'')].type.description', null, 'secure/offenders/crn/$crn/registrations'),
-('72a47b79-e4d6-4a35-b9ab-c18b31726303', 'mappa_nominal_category', 'UPW', 'DELIUS', '$.registrations[?(@.type.code==''MAPP'')].registerCategory.code', null, 'secure/offenders/crn/$crn/registrations'),
-('55461397-4fac-48af-a00e-2f4a3d33316d', 'mappa_nominal_level', 'UPW', 'DELIUS', '$.registrations[?(@.type.code==''MAPP'')].registerLevel.code', null, 'secure/offenders/crn/$crn/registrations')
-
+('6a65d799-3796-497c-b09d-8dab9822fb6c', 'upw_reading_writing_difficulties_details', 'UPW', 'DELIUS', '$.personalCircumstances[?(@.personalCircumstanceType.code==''G'')].notes', null, 'secure/offenders/crn/$crn/personalCircumstances')
 ;

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
@@ -274,10 +274,6 @@ class AssessmentControllerCreateTest : IntegrationTest() {
       assertThat(answers?.get("upw_caring_commitments_details")).isEqualTo(listOf("Primary Carer"))
       assertThat(answers?.get("upw_reading_writing_difficulties")).isEqualTo(listOf("YES"))
       assertThat(answers?.get("upw_reading_writing_difficulties_details")).isEqualTo(listOf("Cannot read"))
-
-      assertThat(answers?.get("mappa_nominal_description")).isEqualTo(listOf("MAPPA"))
-      assertThat(answers?.get("mappa_nominal_category")).isEqualTo(listOf("X9"))
-      assertThat(answers?.get("mappa_nominal_level")).isEqualTo(listOf("M0"))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
@@ -140,4 +140,52 @@ class CommunityApiClientTest : IntegrationTest() {
       }
     }
   }
+
+  @Nested
+  @DisplayName("get Delius offender registrations")
+  inner class GetDeliusOffenderRegistrations {
+
+    val crn = "DX12340A"
+
+    @Test
+    fun `returns registrations`() {
+      val response = communityApiRestClient.getRegistrations(crn)
+      assertThat(response?.registrations?.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `get Delius Offender returns not found`() {
+      assertThrows<ExternalApiEntityNotFoundException> {
+        communityApiRestClient.getRegistrations("invalidNotFound")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns bad request`() {
+      assertThrows<ExternalApiInvalidRequestException> {
+        communityApiRestClient.getRegistrations("invalidBadRequest")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns unauthorised`() {
+      assertThrows<ExternalApiAuthorisationException> {
+        communityApiRestClient.getRegistrations("invalidUnauthorized")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns forbidden`() {
+      assertThrows<ExternalApiForbiddenException> {
+        communityApiRestClient.getRegistrations("invalidForbidden")
+      }
+    }
+
+    @Test
+    fun `get Delius Offender returns unknown exception`() {
+      assertThrows<ExternalApiUnknownException> {
+        communityApiRestClient.getRegistrations("invalidNotKnow")
+      }
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.assessments.restclient.CommunityApiRestClient
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistration
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistrationElement
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistrations
+import java.time.LocalDate
 
 class RisksServiceTest {
   private val communityApiRestClient: CommunityApiRestClient = mockk()
@@ -45,7 +46,8 @@ class RisksServiceTest {
             riskColour = "Red",
             registerCategory = CommunityRegistrationElement("M2", "MAPPA Cat 2"),
             registerLevel = CommunityRegistrationElement("M1", "MAPPA Level 1"),
-            type = CommunityRegistrationElement("MAPP", "MAPPA")
+            type = CommunityRegistrationElement("MAPP", "MAPPA"),
+            startDate = LocalDate.parse("2021-10-10"),
           ),
         )
       )
@@ -57,6 +59,7 @@ class RisksServiceTest {
       assertThat(registrations.mappa?.levelDescription).isEqualTo("MAPPA Level 1")
       assertThat(registrations.mappa?.category).isEqualTo("M2")
       assertThat(registrations.mappa?.categoryDescription).isEqualTo("MAPPA Cat 2")
+      assertThat(registrations.mappa?.startDate).isEqualTo(LocalDate.parse("2021-10-10"))
     }
 
     @Test
@@ -69,6 +72,7 @@ class RisksServiceTest {
             riskColour = "Red",
             registerCategory = CommunityRegistrationElement("RC12", "Hate Crime - Disability"),
             type = CommunityRegistrationElement("IRMO", "Hate Crime"),
+            startDate = LocalDate.parse("2021-10-10"),
           ),
         )
       )
@@ -88,12 +92,14 @@ class RisksServiceTest {
             riskColour = "Red",
             registerCategory = CommunityRegistrationElement("RC12", "Hate Crime - Disability"),
             type = CommunityRegistrationElement("IRMO", "Hate Crime"),
+            startDate = LocalDate.parse("2021-10-10"),
           ),
           CommunityRegistration(
             active = true,
             warnUser = false,
             riskColour = "Red",
-            type = CommunityRegistrationElement("RHRH", "High RoSH")
+            type = CommunityRegistrationElement("RHRH", "High RoSH"),
+            startDate = LocalDate.parse("2021-10-10"),
           ),
         )
       )

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
@@ -96,9 +96,11 @@ class RisksServiceTest {
           ),
           CommunityRegistration(
             active = true,
-            warnUser = false,
+            warnUser = true,
             riskColour = "Red",
-            type = CommunityRegistrationElement("RHRH", "High RoSH"),
+            registerCategory = CommunityRegistrationElement("M2", "MAPPA Cat 2"),
+            registerLevel = CommunityRegistrationElement("M1", "MAPPA Level 1"),
+            type = CommunityRegistrationElement("MAPP", "MAPPA"),
             startDate = LocalDate.parse("2021-10-10"),
           ),
         )
@@ -106,7 +108,6 @@ class RisksServiceTest {
 
       val registrations = risksService.getRegistrationsForAssessment(crn)
 
-      assertThat(registrations.mappa).isNull()
       assertThat(registrations.flags.size).isEqualTo(1)
       assertThat(registrations.flags.first().code).isEqualTo("IRMO")
       assertThat(registrations.flags.first().description).isEqualTo("Hate Crime")

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.assessments.services
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.assessments.restclient.CommunityApiRestClient
+import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistration
+import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistrationElement
+import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityRegistrations
+
+class RisksServiceTest {
+  private val communityApiRestClient: CommunityApiRestClient = mockk()
+  private val risksService = RisksService(communityApiRestClient)
+
+  private val crn = "A123456"
+
+  @BeforeEach
+  private fun setup() {
+  }
+
+  @Nested
+  @DisplayName("get offender registrations")
+  inner class GetOffenderRegistrations {
+    @Test
+    fun `handles when there are no registrations`() {
+      every { communityApiRestClient.getRegistrations(crn) } returns CommunityRegistrations(emptyList())
+
+      val registrations = risksService.getRegistrationsForAssessment(crn)
+
+      assertThat(registrations.mappa).isNull()
+      assertThat(registrations.flags.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `returns MAPPA information when available`() {
+      every { communityApiRestClient.getRegistrations(crn) } returns CommunityRegistrations(
+        listOf(
+          CommunityRegistration(
+            active = true,
+            warnUser = true,
+            riskColour = "Red",
+            registerCategory = CommunityRegistrationElement("M2", "MAPPA Cat 2"),
+            registerLevel = CommunityRegistrationElement("M1", "MAPPA Level 1"),
+            type = CommunityRegistrationElement("MAPP", "MAPPA")
+          ),
+        )
+      )
+
+      val registrations = risksService.getRegistrationsForAssessment(crn)
+
+      assertThat(registrations.mappa).isNotNull
+      assertThat(registrations.mappa?.level).isEqualTo("M1")
+      assertThat(registrations.mappa?.levelDescription).isEqualTo("MAPPA Level 1")
+      assertThat(registrations.mappa?.category).isEqualTo("M2")
+      assertThat(registrations.mappa?.categoryDescription).isEqualTo("MAPPA Cat 2")
+    }
+
+    @Test
+    fun `handles when there is no MAPPA information`() {
+      every { communityApiRestClient.getRegistrations(crn) } returns CommunityRegistrations(
+        listOf(
+          CommunityRegistration(
+            active = true,
+            warnUser = true,
+            riskColour = "Red",
+            registerCategory = CommunityRegistrationElement("RC12", "Hate Crime - Disability"),
+            type = CommunityRegistrationElement("IRMO", "Hate Crime"),
+          ),
+        )
+      )
+
+      val registrations = risksService.getRegistrationsForAssessment(crn)
+
+      assertThat(registrations.mappa).isNull()
+    }
+
+    @Test
+    fun `returns active and selected registrations as flags`() {
+      every { communityApiRestClient.getRegistrations(crn) } returns CommunityRegistrations(
+        listOf(
+          CommunityRegistration(
+            active = true,
+            warnUser = true,
+            riskColour = "Red",
+            registerCategory = CommunityRegistrationElement("RC12", "Hate Crime - Disability"),
+            type = CommunityRegistrationElement("IRMO", "Hate Crime"),
+          ),
+          CommunityRegistration(
+            active = true,
+            warnUser = false,
+            riskColour = "Red",
+            type = CommunityRegistrationElement("RHRH", "High RoSH")
+          ),
+        )
+      )
+
+      val registrations = risksService.getRegistrationsForAssessment(crn)
+
+      assertThat(registrations.mappa).isNull()
+      assertThat(registrations.flags.size).isEqualTo(1)
+      assertThat(registrations.flags.first().code).isEqualTo("IRMO")
+      assertThat(registrations.flags.first().description).isEqualTo("Hate Crime")
+      assertThat(registrations.flags.first().colour).isEqualTo("Red")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.assessments.restclient.communityapi.OffenderLangua
 import uk.gov.justice.digital.assessments.restclient.communityapi.OffenderProfile
 import uk.gov.justice.digital.assessments.restclient.communityapi.Phone
 import uk.gov.justice.digital.assessments.restclient.communityapi.Type
+import java.time.LocalDate
 
 class CommunityApiMockServer : WireMockServer(9096) {
 
@@ -402,7 +403,8 @@ class CommunityApiMockServer : WireMockServer(9096) {
                       riskColour = "Red",
                       registerCategory = CommunityRegistrationElement("M2", "MAPPA Cat 2"),
                       registerLevel = CommunityRegistrationElement("M1", "MAPPA Level 1"),
-                      type = CommunityRegistrationElement("MAPP", "MAPPA")
+                      type = CommunityRegistrationElement("MAPP", "MAPPA"),
+                      startDate = LocalDate.parse("2021-10-10"),
                     ),
                     CommunityRegistration(
                       active = true,
@@ -410,12 +412,14 @@ class CommunityApiMockServer : WireMockServer(9096) {
                       riskColour = "Red",
                       registerCategory = CommunityRegistrationElement("RC12", "Hate Crime - Disability"),
                       type = CommunityRegistrationElement("IRMO", "Hate Crime"),
+                      startDate = LocalDate.parse("2021-10-10"),
                     ),
                     CommunityRegistration(
                       active = true,
                       warnUser = false,
                       riskColour = "Red",
-                      type = CommunityRegistrationElement("RHRH", "High RoSH")
+                      type = CommunityRegistrationElement("RHRH", "High RoSH"),
+                      startDate = LocalDate.parse("2021-10-10"),
                     ),
                   )
                 )


### PR DESCRIPTION
This PR is to create an endpoint to return MAPPA and Risk Flags from offender registrations

Endpoint:`/assessments/{crn}/registrations`

Response:

```JSON
{
  "mappa": {
    "level": "M1",
    "levelDescription": "MAPPA Level 1",
    "category": "M2",
    "categoryDescription": "MAPPA Cat 1",
    "startDate": "2021-10-10"
  },
  "flags": [
    { "code": "IRMO", "description": "Hate Crime", "colour": "Red" }
  ]
}
```