### PR TITLE
Update Known Adult ROSH risk to match ARN API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/RoshRiskSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/RoshRiskSummaryDto.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Risk
 import java.time.LocalDate
 
 fun getRiskLevel(riskInCommunityDto: RiskInCommunityDto, risk: String): String {
-  return if (riskInCommunityDto.high.contains(risk)) { "HIGH" } else if (riskInCommunityDto.medium.contains(risk)) { "MEDIUM" } else if (riskInCommunityDto.low.contains(risk)) { "LOW" } else { "NOT_KNOWN" }
+  return if (riskInCommunityDto.veryHigh.contains(risk)) { "VERY_HIGH" } else if (riskInCommunityDto.high.contains(risk)) { "HIGH" } else if (riskInCommunityDto.medium.contains(risk)) { "MEDIUM" } else if (riskInCommunityDto.low.contains(risk)) { "LOW" } else { "NOT_KNOWN" }
 }
 
 data class RoshRiskSummaryDto(
@@ -35,9 +35,8 @@ data class RoshRiskSummaryDto(
         lastUpdated = riskSummary.assessedOn,
         riskToChildrenInCommunity = getRiskLevel(riskSummary.riskInCommunity, "Children"),
         riskToPublicInCommunity = getRiskLevel(riskSummary.riskInCommunity, "Public"),
-        riskToKnownAdultInCommunity = getRiskLevel(riskSummary.riskInCommunity, "Known adult"),
+        riskToKnownAdultInCommunity = getRiskLevel(riskSummary.riskInCommunity, "Known Adult"),
         riskToStaffInCommunity = getRiskLevel(riskSummary.riskInCommunity, "Staff"),
-
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskSummary.kt
@@ -10,6 +10,8 @@ data class RiskSummary(
 )
 
 class RiskInCommunityDto(
+  @JsonProperty("VERY_HIGH")
+  val veryHigh: Collection<String> = emptyList(),
   @JsonProperty("HIGH")
   val high: Collection<String> = emptyList(),
   @JsonProperty("MEDIUM")

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/RisksServiceTest.kt
@@ -129,7 +129,7 @@ class RisksServiceTest {
         assessedOn = LocalDate.parse("2021-10-10"),
         riskInCommunity = RiskInCommunityDto(
           high = listOf("Public"),
-          medium = listOf("Known adult", "Staff"),
+          medium = listOf("Known Adult", "Staff"),
           low = listOf("Children"),
         )
       )


### PR DESCRIPTION
Going by this snippet from the ARN API codebase
```kotlin
    return listOf(
      "Children" to children,
      "Public" to public,
      "Known Adult" to knowAdult,
      "Staff" to staff,
      "Prisoners" to prisoners
    ).groupBy({ it.second }, { it.first }).filterKeys { it != null }
 ```
 Looks like it should have been `Known Adult`, I've also added support for `VERY_HIGH` as a risk level