### PR TITLE
Accept Event Index and Event (Delius Conviction) IDs when creating an…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentDto.kt
@@ -7,6 +7,9 @@ data class CreateAssessmentDto(
   @Schema(description = "Delius Event ID", example = "1234")
   val deliusEventId: Long? = null,
 
+  @Schema(description = "Delius Event Type", example = "1234")
+  val deliusEventType: DeliusEventType = DeliusEventType.EVENT_INDEX,
+
   @Schema(description = "Offender CRN", example = "CRN1")
   val crn: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentDto.kt
@@ -7,7 +7,7 @@ data class CreateAssessmentDto(
   @Schema(description = "Delius Event ID", example = "1234")
   val deliusEventId: Long? = null,
 
-  @Schema(description = "Delius Event Type", example = "1234")
+  @Schema(description = "Delius Event Type", example = "EVENT_ID", required = false)
   val deliusEventType: DeliusEventType = DeliusEventType.EVENT_INDEX,
 
   @Schema(description = "Offender CRN", example = "CRN1")

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentEpisodeDto.kt
@@ -13,6 +13,6 @@ data class CreateAssessmentEpisodeDto(
   @Schema(description = "Assessment Schema Code", example = "ROSH")
   val assessmentSchemaCode: AssessmentSchemaCode,
 
-  @Schema(description = "Delius Event Type", example = "1234")
+  @Schema(description = "Delius Event Type", example = "EVENT_ID", required = false)
   val deliusEventType: DeliusEventType = DeliusEventType.EVENT_INDEX
 )

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/CreateAssessmentEpisodeDto.kt
@@ -11,5 +11,8 @@ data class CreateAssessmentEpisodeDto(
   val eventID: Long,
 
   @Schema(description = "Assessment Schema Code", example = "ROSH")
-  val assessmentSchemaCode: AssessmentSchemaCode
+  val assessmentSchemaCode: AssessmentSchemaCode,
+
+  @Schema(description = "Delius Event Type", example = "1234")
+  val deliusEventType: DeliusEventType = DeliusEventType.EVENT_INDEX
 )

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/DeliusEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/DeliusEventType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.assessments.api
+
+enum class DeliusEventType {
+  EVENT_INDEX, EVENT_ID
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/OffenceDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/OffenceDto.kt
@@ -7,6 +7,13 @@ import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityOffen
 import java.time.LocalDate
 
 data class OffenceDto(
+
+  @Schema(description = "Conviction ID")
+  val convictionId: Long? = null,
+
+  @Schema(description = "Conviction Index")
+  val convictionIndex: Long? = null,
+
   @Schema(description = "Offence category code")
   val offenceCode: String? = null,
 
@@ -27,6 +34,8 @@ data class OffenceDto(
     fun from(convictionDto: CommunityConvictionDto): OffenceDto {
       val offence = getMainOffence(convictionDto.offences)
       return OffenceDto(
+        convictionId = convictionDto.convictionId,
+        convictionIndex = convictionDto.index,
         offenceCode = offence.detail?.mainCategoryCode,
         codeDescription = offence.detail?.mainCategoryDescription,
         offenceSubCode = offence.detail?.subCategoryCode,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
@@ -85,7 +85,8 @@ class AssessmentController(
       assessmentUuid,
       createAssessmentEpisodeDto.eventID,
       createAssessmentEpisodeDto.changeReason,
-      createAssessmentEpisodeDto.assessmentSchemaCode
+      createAssessmentEpisodeDto.assessmentSchemaCode,
+      createAssessmentEpisodeDto.deliusEventType
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiRestClient.kt
@@ -87,6 +87,32 @@ class CommunityApiRestClient {
       .block()
   }
 
+  fun getConviction(crn: String, convictionId: Long): CommunityConvictionDto? {
+    log.info("Client retrieving conviction details for crn: $crn")
+    val path = "secure/offenders/crn/$crn/convictions/$convictionId"
+    return webClient
+      .get(path)
+      .retrieve()
+      .onStatus(HttpStatus::is4xxClientError) {
+        handle4xxError(
+          it,
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
+      .onStatus(HttpStatus::is5xxServerError) {
+        handle5xxError(
+          "Failed to retrieve conviction details for crn: $crn and conviction ID $convictionId",
+          HttpMethod.GET,
+          path,
+          ExternalService.COMMUNITY_API
+        )
+      }
+      .bodyToMono(CommunityConvictionDto::class.java)
+      .block()
+  }
+
   fun getRegistrations(crn: String): CommunityRegistrations? {
     log.info("Client retrieving registrations for crn: $crn")
     val path = "secure/offenders/crn/$crn/registrations"

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/OffenderService.kt
@@ -32,12 +32,19 @@ class OffenderService(
     return OffenderDto.from(communityOffenderDto)
   }
 
-  fun getOffence(crn: String, eventId: Long): OffenceDto {
+  fun getOffenceFromConvictionIndex(crn: String, eventId: Long): OffenceDto {
     log.info("Requesting offences for crn: $crn")
     val convictions = communityApiRestClient.getConvictions(crn)
       ?: throw EntityNotFoundException("Could not get convictions for crn: $crn")
     val conviction = convictions.find { it.index == eventId }
       ?: throw EntityNotFoundException("Could not get conviction for crn: $crn, event ID: $eventId")
+    return OffenceDto.from(conviction)
+  }
+
+  fun getOffenceFromConvictionId(crn: String, convictionId: Long): OffenceDto {
+    log.info("Requesting offences for crn: $crn")
+    val conviction = communityApiRestClient.getConviction(crn, convictionId)
+      ?: throw EntityNotFoundException("Could not get convictions for crn: $crn")
     return OffenceDto.from(conviction)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/utils/offenderStubResource/OffenderStubService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/utils/offenderStubResource/OffenderStubService.kt
@@ -55,7 +55,7 @@ class OffenderStubService(
   }
 
   fun createOffenderAndOffenceStub(crn: String): OffenderAndOffenceStubDto {
-    val offenceDetail = offenderService.getOffence(crn, EVENT_ID)
+    val offenceDetail = offenderService.getOffenceFromConvictionIndex(crn, EVENT_ID)
     val newOffenderStubDto = createOffenderStubDto(crn)
     assessmentUpdateRestClient.createOasysOffenderStub(newOffenderStubDto)
     return OffenderAndOffenceStubDto.from(newOffenderStubDto, offenceDetail)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/CommunityApiClientTest.kt
@@ -22,7 +22,8 @@ class CommunityApiClientTest : IntegrationTest() {
   @DisplayName("get Delius offender details")
   inner class GetDeliusOffenderDetails {
 
-    val crn = "DX12340A"
+    private val crn = "DX12340A"
+    private val convictionId = 123456L
 
     @Test
     fun `get Delius Offender returns offender DTO`() {
@@ -74,19 +75,31 @@ class CommunityApiClientTest : IntegrationTest() {
     }
 
     @Test
-    fun `get Delius Conviction returns conviction DTO`() {
+    fun `get Delius Convictions returns conviction DTO`() {
       val convictions = communityApiRestClient.getConvictions(crn)
       assertThat(convictions?.get(0)?.convictionId).isEqualTo(2500000223L)
-
+      assertThat(convictions?.get(0)?.index).isEqualTo(1)
       assertThat(convictions?.get(0)?.offences?.get(0)?.mainOffence).isEqualTo(true)
       assertThat(convictions?.get(0)?.offences?.get(0)?.offenceId).isEqualTo("M2500000223")
-
       assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.mainCategoryCode).isEqualTo("046")
       assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.mainCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
       assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.subCategoryCode).isEqualTo("00")
       assertThat(convictions?.get(0)?.offences?.get(0)?.detail?.subCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
-
       assertThat(convictions?.get(0)?.sentence?.startDate).isEqualTo(LocalDate.of(2014, 8, 25))
+    }
+
+    @Test
+    fun `get Delius Conviction returns conviction DTO`() {
+      val conviction = communityApiRestClient.getConviction(crn, convictionId)
+      assertThat(conviction?.convictionId).isEqualTo(convictionId)
+      assertThat(conviction?.index).isEqualTo(1)
+      assertThat(conviction?.offences?.get(0)?.mainOffence).isEqualTo(true)
+      assertThat(conviction?.offences?.get(0)?.offenceId).isEqualTo("M2500000223")
+      assertThat(conviction?.offences?.get(0)?.detail?.mainCategoryCode).isEqualTo("046")
+      assertThat(conviction?.offences?.get(0)?.detail?.mainCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
+      assertThat(conviction?.offences?.get(0)?.detail?.subCategoryCode).isEqualTo("00")
+      assertThat(conviction?.offences?.get(0)?.detail?.subCategoryDescription).isEqualTo("Stealing from shops and stalls (shoplifting)")
+      assertThat(conviction?.sentence?.startDate).isEqualTo(LocalDate.of(2014, 8, 25))
     }
   }
 
@@ -94,8 +107,8 @@ class CommunityApiClientTest : IntegrationTest() {
   @DisplayName("Delius LAO rules")
   inner class DeliusLAORules {
 
-    val validCRN = "DX12340A"
-    val invalidCRN = "OX123456"
+    private val validCRN = "DX12340A"
+    private val invalidCRN = "OX123456"
 
     @Test
     fun `verify Offender Access returns DTO`() {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.assessments.api.DeliusEventType
 import uk.gov.justice.digital.assessments.api.OffenceDto
 import uk.gov.justice.digital.assessments.jpa.entities.AssessmentSchemaCode
 import uk.gov.justice.digital.assessments.jpa.entities.assessments.AssessmentEntity
@@ -118,7 +119,7 @@ class AssessmentServiceTest {
       )
       every { assessmentRepository.findByAssessmentUuid(assessmentUuid) } returns assessment
       every { assessment.subject } returns SubjectEntity(crn = crn, dateOfBirth = LocalDate.now())
-      every { offenderService.getOffence(crn, eventId) } returns OffenceDto(
+      every { offenderService.getOffenceFromConvictionIndex(crn, eventId) } returns OffenceDto(
         offenceCode = offenceCode,
         codeDescription = codeDescription,
         offenceSubCode = offenceSubCode,
@@ -130,7 +131,8 @@ class AssessmentServiceTest {
         assessmentUuid,
         eventId,
         "Change of Circs",
-        assessmentSchemaCode
+        assessmentSchemaCode,
+        DeliusEventType.EVENT_INDEX
       )
 
       assertThat(episodeDto.assessmentUuid).isEqualTo(assessmentUuid)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderServiceTest.kt
@@ -32,6 +32,7 @@ class OffenderServiceTest {
   private val oasysOffenderPk = 101L
   private val crn = "DX12340A"
   private val eventId = 1L
+  private val convictionId = 123456L
 
   @Test
   fun `return offender`() {
@@ -43,10 +44,12 @@ class OffenderServiceTest {
   }
 
   @Test
-  fun `return offence`() {
+  fun `return offence for convictions`() {
     every { communityApiRestClient.getConvictions(crn) } returns validCommunityConvictionsDto()
 
-    val offenceDto = offenderService.getOffence(crn, eventId)
+    val offenceDto = offenderService.getOffenceFromConvictionIndex(crn, eventId)
+    assertThat(offenceDto.convictionId).isEqualTo(636401162L)
+    assertThat(offenceDto.convictionIndex).isEqualTo(1)
     assertThat(offenceDto.offenceCode).isEqualTo("Code")
     assertThat(offenceDto.codeDescription).isEqualTo("Code description")
     assertThat(offenceDto.offenceSubCode).isEqualTo("Sub code")
@@ -54,6 +57,22 @@ class OffenderServiceTest {
 
     verify(exactly = 1) { communityApiRestClient.getConvictions(any()) }
   }
+
+  @Test
+  fun `return offence for conviction`() {
+    every { communityApiRestClient.getConviction(crn, convictionId) } returns validCommunityConvictionsDto()[0]
+
+    val offenceDto = offenderService.getOffenceFromConvictionId(crn, convictionId)
+    assertThat(offenceDto.convictionId).isEqualTo(636401162L)
+    assertThat(offenceDto.convictionIndex).isEqualTo(1)
+    assertThat(offenceDto.offenceCode).isEqualTo("Code")
+    assertThat(offenceDto.codeDescription).isEqualTo("Code description")
+    assertThat(offenceDto.offenceSubCode).isEqualTo("Sub code")
+    assertThat(offenceDto.subCodeDescription).isEqualTo("Sub code description")
+
+    verify(exactly = 1) { communityApiRestClient.getConviction(crn, convictionId) }
+  }
+
   // TODO from ARN-618: Fix offender service
 //  @Test
 //  fun `return offender and offence`() {

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderStubServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/OffenderStubServiceTest.kt
@@ -42,7 +42,7 @@ class OffenderStubServiceTest {
     every { assessmentApiRestClient.getOffenderStubs() } returns offenderStubs()
     every { communityApiRestClient.getPrimaryIds(0, pageSize) } returns primaryIdentifiers()
     every { communityApiRestClient.getOffender(crn) } returns communityOffenderDto()
-    every { offenderService.getOffence(crn, 1) } returns offenceDto()
+    every { offenderService.getOffenceFromConvictionIndex(crn, 1) } returns offenceDto()
     justRun { assessmentUpdateRestClient.createOasysOffenderStub(any()) }
 
     val offenderOffenceDetails = offenderStubService.createOffenderAndOffenceStub()
@@ -99,7 +99,7 @@ class OffenderStubServiceTest {
         pncNumber = "A/1234560BA"
       )
     )
-    every { offenderService.getOffence(crn, 1) } returns offenceDto()
+    every { offenderService.getOffenceFromConvictionIndex(crn, 1) } returns offenceDto()
     justRun { assessmentUpdateRestClient.createOasysOffenderStub(any()) }
 
     val offenderOffenceDetails = offenderStubService.createStubFromCrn(crn)

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
@@ -521,6 +521,22 @@ class CommunityApiMockServer : WireMockServer(9096) {
             .withBody(convictionsJson)
         )
     )
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/DX12340A/convictions/123456"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(convictionJson)
+        )
+    )
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/secure/offenders/crn/X1356/convictions/123456"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(convictionJson)
+        )
+    )
   }
 
   fun stubGetPrimaryIds() {
@@ -865,6 +881,81 @@ class CommunityApiMockServer : WireMockServer(9096) {
       "empty": false
     }
   """.trimIndent()
+
+  private val convictionJson = """
+    {
+        "convictionId": 123456,
+        "index": "1",
+        "active": true,
+        "inBreach": false,
+        "failureToComplyCount": 0,
+        "awaitingPsr": false,
+        "referralDate": "2013-10-26",
+        "offences": [
+            {
+                "offenceId": "M2500000223",
+                "mainOffence": true,
+                "detail": {
+                    "code": "04600",
+                    "description": "Stealing from shops and stalls (shoplifting) - 04600",
+                    "mainCategoryCode": "046",
+                    "mainCategoryDescription": "Stealing from shops and stalls (shoplifting)",
+                    "mainCategoryAbbreviation": "Stealing from shops and stalls (shoplifting)",
+                    "ogrsOffenceCategory": "Theft (Non-motor)",
+                    "subCategoryCode": "00",
+                    "subCategoryDescription": "Stealing from shops and stalls (shoplifting)",
+                    "form20Code": "52"
+                },
+                "offenceDate": "2013-03-06T00:00:00",
+                "offenceCount": 1,
+                "offenderId": 2500000784,
+                "createdDatetime": "1900-01-01T00:00:00",
+                "lastUpdatedDatetime": "1900-01-01T00:00:00"
+            }
+        ],
+        "sentence": {
+            "sentenceId": 2500000179,
+            "description": "CJA - Community Order",
+            "originalLength": 12,
+            "originalLengthUnits": "Months",
+            "defaultLength": 12,
+            "lengthInDays": 365,
+            "unpaidWork": {
+                "minutesOrdered": 6000,
+                "minutesCompleted": 0,
+                "appointments": {
+                    "total": 0,
+                    "attended": 0,
+                    "acceptableAbsences": 0,
+                    "unacceptableAbsences": 0,
+                    "noOutcomeRecorded": 0
+                },
+                "status": "Being Worked"
+            },
+            "startDate": "2014-08-25",
+            "sentenceType": {
+                "code": "SP",
+                "description": "CJA - Community Order"
+            },
+            "failureToComplyLimit": 2
+        },
+        "latestCourtAppearanceOutcome": {
+            "code": "201",
+            "description": "CJA - Community Order"
+        },
+        "courtAppearance": {
+            "courtAppearanceId": 2500000265,
+            "appearanceDate": "2013-10-26T00:00:00",
+            "courtCode": "CWMBMC",
+            "courtName": "Cwmbran Magistrates Court",
+            "appearanceType": {
+                "code": "S",
+                "description": "Sentence"
+            },
+            "crn": "D001305"
+        }
+    }
+"""
 
   private val laoSuccess = """{
       "exclusionMessage": null,


### PR DESCRIPTION
This adds an additional Delius Event Type enum which allows the create Assessment and create Episode endpoints to accept either a conviction ID or a conviction index for the Event ID.

The value of the Delius Event Type is set to EVENT_INDEX by default. This is the existing behaviour and will allow existing integrations to continue working. To enable the new functionality a change is required in the frontend assessment-from-delius endpoint to set the value to EVENT_ID

This is required to handle requests from both Delius and OASys. Delius will pass in an actual conviction ID which allows us to get the conviction from the Community API using the ID and CRN. OASys does not store the conviction ID and only has the index of the conviction. This requires us to get all convictions for a CRN and then select the one which has the passed in index. OASys requires the conviction index to create an offender and so where the conviction ID is provided the index is retrieved. 

We now store the Conviction ID and the Index against the offender offence record. This will allow calls to both OASys (with the index) and Delius (with the Conviction ID) to be made. The conviction ID will be required to create the UPW PDF Contact.



