### PR TITLE
Add endpoint to close assessment episodes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentEpisodeDto.kt
@@ -53,6 +53,9 @@ data class AssessmentEpisodeDto(
 
   @Schema(description = "Date last edited")
   val lastEditedDate: LocalDateTime? = null,
+
+  @Schema(description = "Date closed")
+  val closedDate: LocalDateTime? = null,
 ) {
   companion object {
 
@@ -81,6 +84,7 @@ data class AssessmentEpisodeDto(
         OffenceDto.from(episode.offence),
         episode.tables ?: mutableMapOf(),
         episode.lastEditedDate,
+        episode.closedDate,
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/AssessmentController.kt
@@ -147,6 +147,24 @@ class AssessmentController(
     return updateResponse(assessmentUpdateService.updateEpisode(episode, episodeAnswers))
   }
 
+  @RequestMapping(path = ["/assessments/{assessmentUuid}/episodes/{episodeUuid}/close"], method = [RequestMethod.GET])
+  @Operation(description = "Closes an episode")
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "OK"),
+      ApiResponse(responseCode = "401", description = "Invalid JWT Token"),
+      ApiResponse(responseCode = "422", description = "The update couldn't be processed")
+    ]
+  )
+  @PreAuthorize("hasRole('ROLE_PROBATION')")
+  fun closeAssessmentEpisode(
+    @Parameter(description = "Assessment UUID", required = true, example = "1234") @PathVariable assessmentUuid: UUID,
+    @Parameter(description = "Episode UUID", required = true) @PathVariable episodeUuid: UUID,
+  ): ResponseEntity<AssessmentEpisodeDto> {
+    val episode = assessmentService.getEpisode(assessmentUuid, episodeUuid)
+    return updateResponse(assessmentUpdateService.closeEpisode(episode))
+  }
+
   @RequestMapping(
     path = ["/assessments/{assessmentUuid}/episodes/current/table/{tableName}"],
     method = [RequestMethod.POST]
@@ -325,7 +343,7 @@ class AssessmentController(
     @Parameter(description = "Assessment UUID", required = true, example = "1234") @PathVariable assessmentUuid: UUID,
   ): ResponseEntity<AssessmentEpisodeDto> {
     val currentEpisode = assessmentService.getCurrentEpisode(assessmentUuid)
-    return updateResponse(assessmentUpdateService.closeEpisode(currentEpisode))
+    return updateResponse(assessmentUpdateService.completeEpisode(currentEpisode))
   }
 
   @RequestMapping(path = ["/assessments/schema/{assessmentSchemaCode}"], method = [RequestMethod.GET])

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/controllers/advice/ControllerAdvice.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import uk.gov.justice.digital.assessments.api.ErrorResponse
+import uk.gov.justice.digital.assessments.services.exceptions.CannotCloseEpisodeException
 import uk.gov.justice.digital.assessments.services.exceptions.CrnIsMandatoryException
 import uk.gov.justice.digital.assessments.services.exceptions.DuplicateOffenderRecordException
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
@@ -186,6 +187,13 @@ class ControllerAdvice {
       ),
       HttpStatus.FORBIDDEN
     )
+  }
+
+  @ExceptionHandler(CannotCloseEpisodeException::class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  fun handle(e: CannotCloseEpisodeException): ResponseEntity<ErrorResponse?> {
+    log.info("CannotCloseEpisodeException: {}", e.message)
+    return ResponseEntity(ErrorResponse(status = 400, developerMessage = e.message), HttpStatus.BAD_REQUEST)
   }
 
   @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AssessmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AssessmentEntity.kt
@@ -43,15 +43,15 @@ class AssessmentEntity(
 ) : Serializable {
 
   fun getCurrentEpisode(): AssessmentEpisodeEntity? {
-    return episodes.firstOrNull { !it.isClosed() }
+    return episodes.firstOrNull { !it.isComplete() && !it.isClosed() }
   }
 
   fun hasCurrentEpisode(): Boolean {
-    return episodes.indexOfFirst { !it.isClosed() } >= 0
+    return episodes.indexOfFirst { !it.isComplete() && !it.isClosed() } >= 0
   }
 
   fun getLatestClosedEpisodeOfType(assessmentSchemaCode: AssessmentSchemaCode): AssessmentEpisodeEntity? {
-    return episodes.filter { it.assessmentSchemaCode == assessmentSchemaCode && it.isClosed() }
+    return episodes.filter { it.assessmentSchemaCode == assessmentSchemaCode && it.isComplete() }
       .maxByOrNull { it.endDate!! }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AssessmentEpisodeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/jpa/entities/assessments/AssessmentEpisodeEntity.kt
@@ -74,12 +74,23 @@ data class AssessmentEpisodeEntity(
 
   @Column(name = "last_edited_date")
   var lastEditedDate: LocalDateTime = LocalDateTime.now(),
+
+  @Column(name = "closed_date")
+  var closedDate: LocalDateTime? = null,
 ) {
-  fun isClosed(): Boolean {
+  fun isComplete(): Boolean {
     return endDate != null
   }
 
-  fun close() {
+  fun complete() {
     endDate = LocalDateTime.now()
+  }
+
+  fun isClosed(): Boolean {
+    return closedDate != null
+  }
+
+  fun close() {
+    closedDate = LocalDateTime.now()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
@@ -92,8 +92,8 @@ class AssessmentUpdateService(
     episode.lastEditedDate = LocalDateTime.now()
 
     val oasysResult = oasysAssessmentUpdateService.completeOASysAssessment(episode, offenderPk)
-    if (oasysResult?.hasErrors() == true) {
-      log.info("Unable to complete episode ${episode.episodeUuid} for assessment ${episode.assessment?.assessmentUuid} with OASys restclient")
+    if (oasysResult.hasErrors()) {
+      log.info("Unable to complete episode ${episode.episodeUuid} for assessment ${episode.assessment.assessmentUuid} with OASys restclient")
     } else {
       episode.complete()
       episodeRepository.save(episode)
@@ -347,7 +347,7 @@ class AssessmentUpdateService(
     )
     episode.assessment.subject?.crn?.let {
       telemetryService.trackAssessmentEvent(
-        TelemetryEventType.ASSESSMENT_COMPLETE,
+        TelemetryEventType.ASSESSMENT_CLOSED,
         it,
         episode.author,
         episode.assessment.assessmentUuid,

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateService.kt
@@ -92,7 +92,7 @@ class AssessmentUpdateService(
     episode.lastEditedDate = LocalDateTime.now()
 
     val oasysResult = oasysAssessmentUpdateService.completeOASysAssessment(episode, offenderPk)
-    if (oasysResult.hasErrors()) {
+    if (oasysResult?.hasErrors() == true) {
       log.info("Unable to complete episode ${episode.episodeUuid} for assessment ${episode.assessment.assessmentUuid} with OASys restclient")
     } else {
       episode.complete()

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/TelemetryService.kt
@@ -25,6 +25,7 @@ class TelemetryService(
 
 enum class TelemetryEventType(val eventName: String) {
   ASSESSMENT_CREATED("arnAssessmentCreated"),
+  ASSESSMENT_CLOSED("arnAssessmentClosed"),
   ASSESSMENT_REALLOCATED("arnAssessmentReallocated"),
   ASSESSMENT_COMPLETE("arnAssessmentCompleted")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/exceptions/ApplicationExceptions.kt
@@ -37,6 +37,11 @@ class DuplicateOffenderRecordException(
   val reason: ExceptionReason = DUPLICATE_OFFENDER_RECORD
 ) : RuntimeException(msg)
 
+class CannotCloseEpisodeException(
+  msg: String?,
+  val extraInfoMessage: String? = null,
+) : RuntimeException(msg)
+
 // External Services Exceptions
 class ExternalApiEntityNotFoundException(
   msg: String,

--- a/src/main/resources/db/migration/assessments/V1_7__episode_closed_date.sql
+++ b/src/main/resources/db/migration/assessments/V1_7__episode_closed_date.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlResolveForFile
+
+ALTER TABLE assessed_episode ADD COLUMN closed_date TIMESTAMP;

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCloseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceCloseTest.kt
@@ -53,7 +53,7 @@ class AssessmentUpdateServiceCloseTest {
     justRun { auditService.createAuditEvent(any(), any(), any(), any(), any(), any()) }
     justRun {
       telemetryService.trackAssessmentEvent(
-        TelemetryEventType.ASSESSMENT_COMPLETE,
+        TelemetryEventType.ASSESSMENT_CLOSED,
         any(),
         any(),
         any(),
@@ -82,7 +82,7 @@ class AssessmentUpdateServiceCloseTest {
     justRun { auditService.createAuditEvent(any(), any(), any(), any(), any(), any()) }
     justRun {
       telemetryService.trackAssessmentEvent(
-        TelemetryEventType.ASSESSMENT_COMPLETE,
+        TelemetryEventType.ASSESSMENT_CLOSED,
         any(),
         any(),
         any(),

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
@@ -94,7 +94,7 @@ class AssessmentUpdateServiceITTest() : IntegrationTest() {
     )
 
     val updateAssessmentResponse =
-      assessmentUpdateService.closeEpisode(assessmentEpisode)
+      assessmentUpdateService.completeEpisode(assessmentEpisode)
     assertThat(updateAssessmentResponse).isEqualTo(
       AssessmentEpisodeDto.from(
         assessmentEpisode,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceTest.kt
@@ -251,7 +251,7 @@ class AssessmentUpdateServiceTest {
     }
 
     @Test
-    fun `do not update a closed episode`() {
+    fun `do not update a completed episode`() {
       val assessment = AssessmentEntity(
         assessmentId = assessmentId,
         episodes = mutableListOf(
@@ -285,7 +285,7 @@ class AssessmentUpdateServiceTest {
         )
       }
         .isInstanceOf(UpdateClosedEpisodeException::class.java)
-        .hasMessage("Cannot update closed Episode $episodeUuid for assessment $assessmentUuid")
+        .hasMessage("Cannot update a closed or completed Episode $episodeUuid for assessment $assessmentUuid")
     }
   }
 


### PR DESCRIPTION
This PR adds an endpoint to close an episode
`GET /assessments/{assessmentUuid}/episodes/{episodeUuid}/close`
I've also added an additional `close_date` column to the `assessment_episode` table to support this functionality