### PR TITLE
Make RiskSummary overallRisk optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskSummary.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
 data class RiskSummary(
-  val overallRiskLevel: String,
+  val overallRiskLevel: String?,
   val riskInCommunity: RiskInCommunityDto,
   val assessedOn: LocalDate,
 )


### PR DESCRIPTION
Updates the RiskSummary DTO in this service to be like the one returned from the ARN API