### PR TITLE
Update Circle/Helm to deploy to live cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,22 @@ workflows:
               only:
                 - main
       - hmpps/deploy_env:
+          name: deploy_live_1_dev
+          env: "live-1-dev"
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - validate
+            - helm_lint
+            - build_docker
+      - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
+          context:
+            - hmpps-common-vars
+            - hmpps-assessments-dev-live
           filters:
             branches:
               only:
@@ -70,10 +84,10 @@ workflows:
       - request-preprod-approval:
           type: approval
           requires:
-            - deploy_dev
+            - deploy_live_1_dev
       - hmpps/deploy_env:
-          name: deploy_preprod
-          env: "preprod"
+          name: deploy_live_1_preprod
+          env: "live-1-preprod"
           context:
             - hmpps-common-vars
             - hmpps-assessments-preprod
@@ -82,10 +96,10 @@ workflows:
       - request-prod-approval:
           type: approval
           requires:
-            - deploy_preprod
+            - deploy_live_1_preprod
       - hmpps/deploy_env:
-          name: deploy_prod
-          env: "prod"
+          name: deploy_live_1_prod
+          env: "live-1-prod"
           context:
             - hmpps-common-vars
             - hmpps-assessments-prod

--- a/helm_deploy/hmpps-assessments-api/templates/ingress.yaml
+++ b/helm_deploy/hmpps-assessments-api/templates/ingress.yaml
@@ -12,8 +12,8 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ .Release.Namespace }}-blue
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ .Release.Namespace }}-{{ .Values.ingress.identifier }}
+    external-dns.alpha.kubernetes.io/aws-weight: {{ .Values.ingress.weighting | quote }}
     {{ if .Values.ingress.enable_allow_list }}
     {{- $primaryAllowList := (include "app.joinListWithComma" .Values.allow_list) -}}
     {{ if $primaryAllowList }}nginx.ingress.kubernetes.io/whitelist-source-range: {{ $primaryAllowList | quote }}{{ end }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -31,6 +31,8 @@ ingress:
   host: api-dev.hmpps-assessments.service.justice.gov.uk
   cert_secret: hmpps-assessments-api-cert
   path: /
+  identifier: green
+  weighting: 0
 
 allow_list:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-live-1-dev.yaml
+++ b/helm_deploy/values-live-1-dev.yaml
@@ -1,7 +1,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: quay.io/hmpps/hmpps-assessments-api
@@ -14,25 +14,25 @@ redis:
 
 env:
   JAVA_OPTS: "-Xmx512m -Duser.timezone=UTC"
-  OAUTH_ENDPOINT_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
-  COURT_CASE_API_BASE_URL: https://court-case-service.apps.live-1.cloud-platform.service.justice.gov.uk
-  ASSESSMENT_UPDATE_API_BASE_URL: https://offender-assessments-updates.hmpps.service.justice.gov.uk
-  COMMUNITY_API_BASE_URL:  https://community-api.probation.service.justice.gov.uk/
-  ASSESSMENT_API_BASE_URL: https://offender-prod.aks-live-1.studio-hosting.service.justice.gov.uk
-  ASSESS_RISKS_AND_NEEDS_API_BASE_URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk/
-  AUDIT_BASE_URL: https://audit-api.hmpps.service.justice.gov.uk
-  SPRING_PROFILES_ACTIVE: "logstash,postgres,preprod"
+  OAUTH_ENDPOINT_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+  COURT_CASE_API_BASE_URL: https://court-case-service-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+  ASSESSMENT_UPDATE_API_BASE_URL: https://asmnt-updte-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
+  COMMUNITY_API_BASE_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io/
+  ASSESSMENT_API_BASE_URL: https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
+  ASSESS_RISKS_AND_NEEDS_API_BASE_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/
+  AUDIT_BASE_URL: https://audit-api-dev.hmpps.service.justice.gov.uk
+  SPRING_PROFILES_ACTIVE: "logstash,postgres,dev"
   STUB_RESTRICTED: "D002593"
   STUB_OFFSET: "200"
 
 ingress:
   enabled: true
   enable_allow_list: true
-  host: api.hmpps-assessments.service.justice.gov.uk
+  host: api-dev.hmpps-assessments.service.justice.gov.uk
   cert_secret: hmpps-assessments-api-cert
   path: /
-  identifier: green
-  weighting: 0
+  identifier: blue
+  weighting: 100
 
 allow_list:
   office: "217.33.148.210/32"
@@ -57,6 +57,4 @@ allow_list:
   cloudplatform-live1-3: "35.177.252.54/32"
 
 generic-prometheus-alerts:
-  enabled: true
-  targetApplication: hmpps-assessments-api
-  alertSeverity: hmpps-assess-risks-and-needs
+  enabled: false

--- a/helm_deploy/values-live-1-preprod.yaml
+++ b/helm_deploy/values-live-1-preprod.yaml
@@ -14,13 +14,13 @@ redis:
 
 env:
   JAVA_OPTS: "-Xmx512m -Duser.timezone=UTC"
-  OAUTH_ENDPOINT_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
-  COURT_CASE_API_BASE_URL: https://court-case-service.apps.live-1.cloud-platform.service.justice.gov.uk
-  ASSESSMENT_UPDATE_API_BASE_URL: https://offender-assessments-updates.hmpps.service.justice.gov.uk
-  COMMUNITY_API_BASE_URL:  https://community-api.probation.service.justice.gov.uk/
-  ASSESSMENT_API_BASE_URL: https://offender-prod.aks-live-1.studio-hosting.service.justice.gov.uk
-  ASSESS_RISKS_AND_NEEDS_API_BASE_URL: https://assess-risks-and-needs.hmpps.service.justice.gov.uk/
-  AUDIT_BASE_URL: https://audit-api.hmpps.service.justice.gov.uk
+  OAUTH_ENDPOINT_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+  COURT_CASE_API_BASE_URL: https://court-case-service-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
+  ASSESSMENT_UPDATE_API_BASE_URL: https://offender-assessments-updates-preprod.hmpps.service.justice.gov.uk
+  COMMUNITY_API_BASE_URL: https://community-api.pre-prod.delius.probation.hmpps.dsd.io/
+  ASSESSMENT_API_BASE_URL: https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk
+  ASSESS_RISKS_AND_NEEDS_API_BASE_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk/
+  AUDIT_BASE_URL: https://audit-api-preprod.hmpps.service.justice.gov.uk
   SPRING_PROFILES_ACTIVE: "logstash,postgres,preprod"
   STUB_RESTRICTED: "D002593"
   STUB_OFFSET: "200"
@@ -28,11 +28,11 @@ env:
 ingress:
   enabled: true
   enable_allow_list: true
-  host: api.hmpps-assessments.service.justice.gov.uk
+  host: api-preprod.hmpps-assessments.service.justice.gov.uk
   cert_secret: hmpps-assessments-api-cert
   path: /
-  identifier: green
-  weighting: 0
+  identifier: blue
+  weighting: 100
 
 allow_list:
   office: "217.33.148.210/32"
@@ -57,6 +57,4 @@ allow_list:
   cloudplatform-live1-3: "35.177.252.54/32"
 
 generic-prometheus-alerts:
-  enabled: true
-  targetApplication: hmpps-assessments-api
-  alertSeverity: hmpps-assess-risks-and-needs
+  enabled: false

--- a/helm_deploy/values-live-1-prod.yaml
+++ b/helm_deploy/values-live-1-prod.yaml
@@ -31,8 +31,8 @@ ingress:
   host: api.hmpps-assessments.service.justice.gov.uk
   cert_secret: hmpps-assessments-api-cert
   path: /
-  identifier: green
-  weighting: 0
+  identifier: blue
+  weighting: 100
 
 allow_list:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -31,6 +31,8 @@ ingress:
   host: api-preprod.hmpps-assessments.service.justice.gov.uk
   cert_secret: hmpps-assessments-api-cert
   path: /
+  identifier: green
+  weighting: 0
 
 allow_list:
   office: "217.33.148.210/32"


### PR DESCRIPTION
This will require the `hmpps-assessments-dev-live` Circle CI Context to be configured before merging

Reading through the `k8s_setup` job in the `hmpps` Circle CI Orb [here](https://github.com/ministryofjustice/hmpps-circleci-orb/blob/main/src/commands/k8s_setup.yml), looks like we will need to configure `KUBE_ENV_NAME` in the Circle CI Context to deploy to the appropriate namespaces