### PR TITLE
ARN-897 Suppress Postgress image warning as it's only run in dev.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,5 +4,3 @@ CVE-2021-23463
 CVE-2021-42392
 # Suppress CVE for h2 as console is not enabled in production
 CVE-2022-23221
-# Suppress CVE for Postres DB as it's a dev only image
-CVE-2022-21724

--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,5 @@ CVE-2021-23463
 CVE-2021-42392
 # Suppress CVE for h2 as console is not enabled in production
 CVE-2022-23221
+# Suppress CVE for Postres DB as it's a dev only image
+CVE-2022-21724

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
   implementation("com.google.code.gson:gson:2.8.8")
   implementation("com.google.guava:guava:30.1.1-jre")
   implementation("org.apache.commons:commons-lang3:3.12.0")
-  implementation("org.postgresql:postgresql")
+  implementation("org.postgresql:postgresql:42.3.2")
   implementation("org.flywaydb:flyway-core:7.15.0")
   runtimeOnly("com.h2database:h2:1.4.200")
 


### PR DESCRIPTION
Suppress Trivy warning re Postgres image as it's not run in prod.