### PR TITLE
Remove Predictor Subtype Enum and use String instead to allow the ups…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskPredictorsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/assessrisksandneedsapi/RiskPredictorsDto.kt
@@ -8,7 +8,7 @@ data class RiskPredictorsDto(
   val calculatedAt: String,
   val type: PredictorType,
   val scoreType: ScoreType,
-  val scores: Map<PredictorSubType, Score>,
+  val scores: Map<String, Score>,
   val errors: List<String> = emptyList()
 )
 
@@ -24,17 +24,6 @@ enum class ScoreLevel(val type: String) {
   companion object {
     fun findByType(type: String): ScoreLevel? {
       return values().firstOrNull { value -> value.type == type }
-    }
-  }
-}
-
-enum class PredictorSubType {
-  RSR, OSPC, OSPI;
-
-  companion object {
-    fun fromString(enumValue: String?): PredictorSubType {
-      return values().firstOrNull { it.name == enumValue }
-        ?: throw IllegalArgumentException("Unknown PredictorSubType $enumValue")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsService.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Curr
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.DynamicScoringOffences
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Gender
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.OffenderAndOffencesDto
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PreviousOffences
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.RiskPredictorsDto
 import uk.gov.justice.digital.assessments.services.dto.EmploymentType
@@ -147,7 +146,9 @@ class RiskPredictorsService(
         "current_relationship_with_partner"
       ).toProblemsLevel(),
       evidenceOfDomesticViolence = getNonRequiredAnswer(answers, "evidence_domestic_violence").toBoolean(),
-      isPerpetrator = getNonRequiredAnswer(answers, "perpetrator_domestic_violence").tempPerpetratorBoolean(getNonRequiredAnswer(answers, "evidence_domestic_violence").toBoolean()),
+      isPerpetrator = getNonRequiredAnswer(answers, "perpetrator_domestic_violence").tempPerpetratorBoolean(
+        getNonRequiredAnswer(answers, "evidence_domestic_violence").toBoolean()
+      ),
       alcoholUseIssues = getNonRequiredAnswer(answers, "use_of_alcohol").toProblemsLevel(),
       bingeDrinkingIssues = getNonRequiredAnswer(answers, "binge_drinking").toProblemsLevel(),
       impulsivityIssues = getNonRequiredAnswer(answers, "impulsivity_issues").toProblemsLevel(),
@@ -182,24 +183,24 @@ class RiskPredictorsService(
   }
 
   private fun RiskPredictorsDto.toRiskPredictorsScores(): Map<String, uk.gov.justice.digital.assessments.api.Score> {
-    val rsrScore = this.scores[PredictorSubType.RSR]
-    val ospcScore = this.scores[PredictorSubType.OSPC]
-    val ospiScore = this.scores[PredictorSubType.OSPI]
+    val rsrScore = this.scores["RSR"]
+    val ospcScore = this.scores["OSPC"]
+    val ospiScore = this.scores["OSPI"]
 
     return mapOf(
-      PredictorSubType.RSR.name to uk.gov.justice.digital.assessments.api.Score(
+      "RSR" to uk.gov.justice.digital.assessments.api.Score(
         rsrScore?.level?.name,
         rsrScore?.score,
         rsrScore?.isValid == true,
         this.calculatedAt
       ),
-      PredictorSubType.OSPC.name to uk.gov.justice.digital.assessments.api.Score(
+      "OSPC" to uk.gov.justice.digital.assessments.api.Score(
         ospcScore?.level?.name,
         ospcScore?.score,
         ospcScore?.isValid == true,
         this.calculatedAt
       ),
-      PredictorSubType.OSPI.name to uk.gov.justice.digital.assessments.api.Score(
+      "OSPI" to uk.gov.justice.digital.assessments.api.Score(
         ospiScore?.level?.name,
         ospiScore?.score,
         ospiScore?.isValid == true,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.assessments.api.ErrorResponse
 import uk.gov.justice.digital.assessments.api.PredictorScoresDto
 import uk.gov.justice.digital.assessments.api.Score
 import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
 import uk.gov.justice.digital.assessments.services.dto.ScoreType
@@ -519,19 +518,19 @@ class AssessmentControllerTest : IntegrationTest() {
             type = PredictorType.RSR,
             scoreType = ScoreType.STATIC,
             scores = mapOf(
-              PredictorSubType.RSR.name to Score(
+              "RSR" to Score(
                 level = ScoreLevel.HIGH.name,
                 score = BigDecimal("11.34"),
                 isValid = true,
                 date = "2021-08-09 14:46:48"
               ),
-              PredictorSubType.OSPC.name to Score(
+              "OSPC" to Score(
                 level = ScoreLevel.NOT_APPLICABLE.name,
                 score = BigDecimal("0"),
                 isValid = false,
                 date = "2021-08-09 14:46:48"
               ),
-              PredictorSubType.OSPI.name to Score(
+              "OSPI" to Score(
                 level = ScoreLevel.NOT_APPLICABLE.name,
                 score = BigDecimal("0"),
                 isValid = false,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/RiskPredictorsControllerTest.kt
@@ -10,7 +10,6 @@ import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.assessments.api.ErrorResponse
 import uk.gov.justice.digital.assessments.api.PredictorScoresDto
 import uk.gov.justice.digital.assessments.api.Score
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
 import uk.gov.justice.digital.assessments.services.dto.ScoreType
@@ -52,19 +51,19 @@ class RiskPredictorsControllerTest : IntegrationTest() {
           type = PredictorType.RSR,
           scoreType = ScoreType.STATIC,
           scores = mapOf(
-            PredictorSubType.RSR.name to Score(
+            "RSR" to Score(
               level = ScoreLevel.HIGH.name,
               score = BigDecimal("11.34"),
               isValid = true,
               date = "2021-08-09 14:46:48"
             ),
-            PredictorSubType.OSPC.name to Score(
+            "OSPC" to Score(
               level = ScoreLevel.NOT_APPLICABLE.name,
               score = BigDecimal("0"),
               isValid = false,
               date = "2021-08-09 14:46:48"
             ),
-            PredictorSubType.OSPI.name to Score(
+            "OSPI" to Score(
               level = ScoreLevel.NOT_APPLICABLE.name,
               score = BigDecimal("0"),
               isValid = false,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessRisksAndNeedsApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/restclient/AssessRisksAndNeedsApiClientTest.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Dyna
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.EmploymentType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Gender
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.OffenderAndOffencesDto
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PreviousOffences
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ProblemsLevel
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.RiskPredictorsDto
@@ -121,9 +120,9 @@ class AssessRisksAndNeedsApiClientTest : IntegrationTest() {
         type = PredictorType.RSR,
         scoreType = ScoreType.STATIC,
         scores = mapOf(
-          PredictorSubType.RSR to Score(level = ScoreLevel.HIGH, score = BigDecimal("11.34"), isValid = true),
-          PredictorSubType.OSPC to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
-          PredictorSubType.OSPI to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
+          "RSR" to Score(level = ScoreLevel.HIGH, score = BigDecimal("11.34"), isValid = true),
+          "OSPC" to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
+          "OSPI" to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
         ),
         calculatedAt = "2021-08-09 14:46:48"
       )

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentUpdateServiceITTest.kt
@@ -20,7 +20,6 @@ import uk.gov.justice.digital.assessments.api.PredictorScoresDto
 import uk.gov.justice.digital.assessments.api.Score
 import uk.gov.justice.digital.assessments.api.UpdateAssessmentEpisodeDto
 import uk.gov.justice.digital.assessments.jpa.repositories.assessments.AssessmentRepository
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.ScoreLevel
 import uk.gov.justice.digital.assessments.services.dto.PredictorType
 import uk.gov.justice.digital.assessments.services.dto.ScoreType
@@ -104,19 +103,19 @@ class AssessmentUpdateServiceITTest() : IntegrationTest() {
             type = PredictorType.RSR,
             scoreType = ScoreType.STATIC,
             scores = mapOf(
-              PredictorSubType.RSR.name to Score(
+              "RSR" to Score(
                 level = ScoreLevel.HIGH.name,
                 score = BigDecimal("11.34"),
                 isValid = true,
                 date = "2021-08-09 14:46:48"
               ),
-              PredictorSubType.OSPC.name to Score(
+              "OSPC" to Score(
                 level = ScoreLevel.NOT_APPLICABLE.name,
                 score = BigDecimal("0"),
                 isValid = false,
                 date = "2021-08-09 14:46:48"
               ),
-              PredictorSubType.OSPI.name to Score(
+              "OSPI" to Score(
                 level = ScoreLevel.NOT_APPLICABLE.name,
                 score = BigDecimal("0"),
                 isValid = false,

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/RiskPredictorsServiceTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Curr
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.DynamicScoringOffences
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Gender
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.OffenderAndOffencesDto
-import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PredictorSubType
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.PreviousOffences
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.RiskPredictorsDto
 import uk.gov.justice.digital.assessments.restclient.assessrisksandneedsapi.Score
@@ -588,9 +587,9 @@ class RiskPredictorsServiceTest {
         type = PredictorType.RSR,
         scoreType = ScoreType.STATIC,
         scores = mapOf(
-          PredictorSubType.RSR to Score(level = ScoreLevel.HIGH, score = BigDecimal("11.34"), isValid = true),
-          PredictorSubType.OSPC to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
-          PredictorSubType.OSPI to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
+          "RSR" to Score(level = ScoreLevel.HIGH, score = BigDecimal("11.34"), isValid = true),
+          "OSPC" to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
+          "OSPI" to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
         ),
         calculatedAt = "2021-08-09 14:46:48"
       )
@@ -658,9 +657,9 @@ class RiskPredictorsServiceTest {
         type = PredictorType.RSR,
         scoreType = ScoreType.STATIC,
         scores = mapOf(
-          PredictorSubType.RSR to Score(level = ScoreLevel.HIGH, score = BigDecimal("11.34"), isValid = true),
-          PredictorSubType.OSPC to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
-          PredictorSubType.OSPI to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
+          "RSR" to Score(level = ScoreLevel.HIGH, score = BigDecimal("11.34"), isValid = true),
+          "OSPC" to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
+          "OSPI" to Score(level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false),
         ),
         calculatedAt = "2021-08-09 14:46:48"
       )


### PR DESCRIPTION
…tream ARN API to add new predictor types without it being a breaking change.