### PR TITLE
Add structured carer commitments data from Delius for UPW

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/CarerCommitmentsAnswerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/CarerCommitmentsAnswerDto.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.assessments.api
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import uk.gov.justice.digital.assessments.restclient.communityapi.DeliusPersonalCircumstanceDto
+
+class CarerCommitmentsAnswerDto(
+  @JsonProperty("description")
+  val description: String,
+
+  @JsonProperty("code")
+  val code: String,
+
+  @JsonProperty("subType")
+  val subType: String,
+
+  @JsonProperty("subTypeCode")
+  val subTypeCode: String,
+
+  @JsonProperty("notes")
+  val notes: String? = null,
+
+  @JsonProperty("isEvidenced")
+  val isEvidenced: Boolean,
+) {
+  companion object {
+
+    fun from(carerCommitments: List<DeliusPersonalCircumstanceDto>): List<CarerCommitmentsAnswerDto> {
+      return if (carerCommitments.isEmpty()) emptyList()
+      else carerCommitments.map { from(it) }
+    }
+
+    fun from(carerCommitment: DeliusPersonalCircumstanceDto): CarerCommitmentsAnswerDto {
+      return CarerCommitmentsAnswerDto(
+        code = carerCommitment.personalCircumstanceType.code,
+        description = carerCommitment.personalCircumstanceType.description,
+        subType = carerCommitment.personalCircumstanceSubType.description,
+        subTypeCode = carerCommitment.personalCircumstanceSubType.code,
+        notes = carerCommitment.notes,
+        isEvidenced = carerCommitment.evidenced,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/DeliusPersonalCircumstanceDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/restclient/communityapi/DeliusPersonalCircumstanceDto.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.assessments.restclient.communityapi
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DeliusPersonalCircumstanceDto(
+  val personalCircumstanceType: PersonalCircumstanceType,
+  val personalCircumstanceSubType: PersonalCircumstanceType,
+  val notes: String? = null,
+  val evidenced: Boolean,
+  val isActive: Boolean,
+)
+
+data class PersonalCircumstanceType(
+  val code: String,
+  val description: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
@@ -12,6 +12,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.assessments.api.CarerCommitmentsAnswerDto
 import uk.gov.justice.digital.assessments.api.DisabilityAnswerDto
 import uk.gov.justice.digital.assessments.api.EmergencyContactDetailsAnswerDto
 import uk.gov.justice.digital.assessments.api.GPDetailsAnswerDto
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.assessments.restclient.AssessmentApiRestClient
 import uk.gov.justice.digital.assessments.restclient.CommunityApiRestClient
 import uk.gov.justice.digital.assessments.restclient.CourtCaseRestClient
 import uk.gov.justice.digital.assessments.restclient.communityapi.DeliusDisabilityDto
+import uk.gov.justice.digital.assessments.restclient.communityapi.DeliusPersonalCircumstanceDto
 import uk.gov.justice.digital.assessments.restclient.communityapi.PersonalContact
 import uk.gov.justice.digital.assessments.services.dto.ExternalSource
 import uk.gov.justice.digital.assessments.services.dto.ExternalSourceQuestionDto
@@ -253,6 +255,10 @@ class EpisodeService(
         val deliusDisabilities = getDisabilitiesFromJson(sourceData, structureQuestion)
         DisabilityAnswerDto.from(deliusDisabilities)
       }
+      "active_carer_commitments" -> {
+        val carerCommitments = getCarerCommitmentsFromJson(sourceData, structureQuestion)
+        CarerCommitmentsAnswerDto.from(carerCommitments)
+      }
       else -> throw ExternalSourceAnswerException("Question code: ${structureQuestion.questionCode} not recognised")
     }
   }
@@ -271,5 +277,13 @@ class EpisodeService(
   ): List<DeliusDisabilityDto> {
     val disabilitiesJson = sourceData.read<JSONArray>(structureQuestion.jsonPathField).toJSONString()
     return objectMapper.readValue(disabilitiesJson)
+  }
+
+  private fun getCarerCommitmentsFromJson(
+    sourceData: DocumentContext,
+    structureQuestion: ExternalSourceQuestionDto
+  ): List<DeliusPersonalCircumstanceDto> {
+    val carerCommitmentsJson = sourceData.read<JSONArray>(structureQuestion.jsonPathField).toJSONString()
+    return objectMapper.readValue(carerCommitmentsJson)
   }
 }

--- a/src/main/resources/db/migration/refdata/V1_21__update_caring_commitments.sql
+++ b/src/main/resources/db/migration/refdata/V1_21__update_caring_commitments.sql
@@ -1,0 +1,14 @@
+-- add individual disability questions
+INSERT INTO question (question_uuid, question_code, question_start, question_end, answer_type, answer_group_uuid, question_text, question_help_text, reference_data_category)
+VALUES
+    ('8f721d80-2b61-4b3d-8f72-7d20a72d2ed0', 'active_carer_commitments', '2021-09-27 14:50:00', null, 'freetext', null, 'Are there carer commitments?', '', null),
+    ('d1d6d2be-bbec-4cd0-bced-927bf24fa614', 'active_carer_commitments_details', '2021-09-27 14:50:00', null, 'freetext', null, 'Additional information (Optional)', '', null);
+
+INSERT INTO external_source_question_mapping (external_source_question_mapping_uuid, question_code, assessment_type, external_source, json_path_field, field_type, external_source_endpoint, mapped_value, if_empty)
+VALUES
+    ('c6dabd44-065c-4419-a696-f993c50860b3', 'active_carer_commitments', 'UPW', 'DELIUS', '$.personalCircumstances[?((@.personalCircumstanceType.code==''I'') && (@.isActive==true))]', 'structured', 'secure/offenders/crn/$crn/personalCircumstances', null, false);
+
+INSERT INTO question_group (question_group_uuid, content_uuid, content_type, group_uuid, display_order, read_only)
+VALUES
+    ('673a829f-7dd5-4064-9703-6e5ddeaec852', '8f721d80-2b61-4b3d-8f72-7d20a72d2ed0', 'question', '28d07199-ceed-473f-8584-156b018d967a', 4, true),
+    ('103d0a46-ffcd-4c28-b807-7b2629e7b19f', 'd1d6d2be-bbec-4cd0-bced-927bf24fa614', 'question', '28d07199-ceed-473f-8584-156b018d967a', 5, true);

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
@@ -367,6 +367,24 @@ class AssessmentControllerCreateTest : IntegrationTest() {
     }
 
     @Test
+    fun `creating a new UPW assessment from Delius returns carer commitments`() {
+      val assessment = createDeliusAssessment("DX5678B", eventID, AssessmentType.UPW)
+
+      val answers = assessment?.episodes?.first()?.answers!!
+
+      val activeCarerCommitments = answers["active_carer_commitments"] as List<*>
+      assertThat(activeCarerCommitments).hasSize(1)
+
+      val carerCommitment = activeCarerCommitments[0] as Map<*, *>
+      assertThat(carerCommitment["description"]).isEqualTo("Dependents")
+      assertThat(carerCommitment["code"]).isEqualTo("I")
+      assertThat(carerCommitment["subType"]).isEqualTo("Is a Primary Carer")
+      assertThat(carerCommitment["subTypeCode"]).isEqualTo("I02")
+      assertThat(carerCommitment["notes"]).isEqualTo("Some notes")
+      assertThat(carerCommitment["isEvidenced"]).isEqualTo(true)
+    }
+
+    @Test
     fun `should pre-populate answers with the 'mapped' type`() {
 
       val dto = CreateAssessmentDto(

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/testutils/CommunityApiMockServer.kt
@@ -290,8 +290,51 @@ class CommunityApiMockServer : WireMockServer(9096) {
                 "            }," +
                 "            \"notes\": \"Some notes\"," +
                 "            \"evidenced\": true," +
+                "            \"isActive\": false," +
                 "            \"createdDatetime\": \"2021-10-25T12:08:42\"," +
                 "            \"lastUpdatedDatetime\": \"2021-10-25T12:08:42\"" +
+                "        }, {" +
+                "            \"personalCircumstanceId\": 2500180004," +
+                "            \"offenderId\": 2500275961," +
+                "            \"personalCircumstanceType\": {" +
+                "                \"code\": \"D\"," +
+                "                \"description\": \"General Health\"" +
+                "            }," +
+                "            \"personalCircumstanceSubType\": {" +
+                "                \"code\": \"D02\"," +
+                "                \"description\": \"Physical Health Concerns\"" +
+                "            }," +
+                "            \"startDate\": \"2021-08-09\"," +
+                "            \"probationArea\": {" +
+                "                \"code\": \"N07\"," +
+                "                \"description\": \"NPS London\"" +
+                "            }," +
+                "            \"notes\": \"Some notes\"," +
+                "            \"evidenced\": true," +
+                "            \"isActive\": true," +
+                "            \"createdDatetime\": \"2021-10-29T18:25:53\"," +
+                "            \"lastUpdatedDatetime\": \"2021-10-29T18:25:53\"" +
+                "        }, {" +
+                "            \"personalCircumstanceId\": 2500179507," +
+                "            \"offenderId\": 2500275961," +
+                "            \"personalCircumstanceType\": {" +
+                "                \"code\": \"I\"," +
+                "                \"description\": \"Dependents\"" +
+                "            }," +
+                "            \"personalCircumstanceSubType\": {" +
+                "                \"code\": \"I02\"," +
+                "                \"description\": \"Is a Primary Carer\"" +
+                "            }," +
+                "            \"startDate\": \"2021-08-09\"," +
+                "            \"probationArea\": {" +
+                "                \"code\": \"N07\"," +
+                "                \"description\": \"NPS London\"" +
+                "            }," +
+                "            \"notes\": \"Some notes\"," +
+                "            \"evidenced\": true," +
+                "            \"isActive\": true," +
+                "            \"createdDatetime\": \"2021-10-28T18:42:20\"," +
+                "            \"lastUpdatedDatetime\": \"2021-10-28T18:42:20\"" +
                 "        }" +
                 "    ]" +
                 "}"


### PR DESCRIPTION
Added the following to the answers payload:

```json
      "active_carer_commitments": [
          {
              "description": "Dependents",
              "code": "I",
              "subType": "Is a Primary Carer",
              "subTypeCode": "I02",
              "isEvidenced": false
          }
      ],
       "active_carer_commitments_details": []
```

and the following will be returned in the questions payload

```json
    {
        "type": "question",
        "questionId": "8f721d80-2b61-4b3d-8f72-7d20a72d2ed0",
        "questionCode": "active_carer_commitments",
        "answerType": "freetext",
        "questionText": "Are there carer commitments?",
        "helpText": "",
        "readOnly": true,
        "conditional": false,
        "referenceDataTargets": [],
        "answerDtos": []
    },
    {
        "type": "question",
        "questionId": "d1d6d2be-bbec-4cd0-bced-927bf24fa614",
        "questionCode": "active_carer_commitments_details",
        "answerType": "freetext",
        "questionText": "Additional information (Optional)",
        "helpText": "",
        "readOnly": true,
        "conditional": false,
        "referenceDataTargets": [],
        "answerDtos": []
    },
```

I've included additional fields around sub types, codes and evidence flags. Assuming that this will future-proof us if we're ever required to surface this information