### PR TITLE
remove pinned flyway dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   implementation("com.google.guava:guava:31.1-jre")
   implementation("org.apache.commons:commons-lang3:3.12.0")
   implementation("org.postgresql:postgresql:42.4.0")
-  implementation("org.flywaydb:flyway-core:8.5.13")
+  implementation("org.flywaydb:flyway-core")
   runtimeOnly("com.h2database:h2:1.4.200")
   implementation("net.logstash.logback:logstash-logback-encoder:7.2")
 


### PR DESCRIPTION
Flyway dependencies are managed by the hmpps gradle plugin 