### PR TITLE
Update external sources mapping to return multiple values

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/EpisodeService.kt
@@ -249,9 +249,9 @@ class EpisodeService(
           if (field.isEmpty()) {
             emptyList<String>()
           } else if (field[0] is Int) {
-            listOf((source.read<JSONArray>(question.jsonPathField).filterNotNull() as List<Integer>).first().toString())
+            (source.read<JSONArray>(question.jsonPathField).filterNotNull() as List<Integer>).map { it.toString() }.toList()
           } else {
-            listOf((source.read<JSONArray>(question.jsonPathField).filterNotNull() as List<String>).first().toString())
+            source.read<JSONArray>(question.jsonPathField).filterNotNull() as List<String>
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerCreateTest.kt
@@ -268,7 +268,7 @@ class AssessmentControllerCreateTest : IntegrationTest() {
       assertThat(answers["caring_commitments"]).isEqualTo(listOf("YES"))
       assertThat(answers["caring_commitments_details"]).isEqualTo(listOf("Primary Carer"))
       assertThat(answers["reading_writing_difficulties"]).isEqualTo(listOf("YES"))
-      assertThat(answers["reading_writing_difficulties_details"]).isEqualTo(listOf("Cannot read"))
+      assertThat(answers["reading_writing_difficulties_details"]).isEqualTo(listOf("Cannot read", "Numeracy difficulties", "Communication difficulties"))
 
       val contact = getStructuredDataFromAnswer(answers, "emergency_contact_details")
       assertThat(contact["emergency_contact_first_name"]).isEqualTo(listOf("Brian"))


### PR DESCRIPTION
I’ve drafted this PR to fix an issue with the existing questions for lit/numeracy, we currently display only the first active record even when there are multiple. 
This PR’s aim to show everything by returning the multiple records in a single array. For example with literacy/numeracy question mappings we are filtering by personal circs type `G` which includes `literacy` `numeracy` and `communication` subtypes, in the current implementation we only display one, even when there are multiple