### PR TITLE
fix broken test which has a fixed age value 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentSubjectDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/api/AssessmentSubjectDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.assessments.api
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.assessments.jpa.entities.assessments.SubjectEntity
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Period
@@ -25,14 +26,12 @@ class AssessmentSubjectDto(
 
   @Schema(description = "Subject Record created Date", example = "2020-01-02T16:00:00")
   val createdDate: LocalDateTime? = null,
+
+  @Schema(description = "Calculated age of subject", example = "22")
+  val age: Int? = null
 ) {
-
-  // TODO: Refactor age so it's not calculated here using LocalDate.now()
-  // Instead calculate in the service from a current date that can be mocked out
-  val age: Int? get() = dob?.let { Period.between(dob, LocalDate.now()).years }
-
   companion object {
-    fun from(subject: SubjectEntity?): AssessmentSubjectDto? {
+    fun from(subject: SubjectEntity?, clock: Clock): AssessmentSubjectDto? {
       if (subject == null) return null
       return AssessmentSubjectDto(
         subject.name,
@@ -40,8 +39,14 @@ class AssessmentSubjectDto(
         subject.crn,
         subject.dateOfBirth,
         subject.gender,
-        subject.createdDate
+        subject.createdDate,
+        calculateAge(subject.dateOfBirth, clock)
       )
+    }
+
+    fun calculateAge(dob: LocalDate?, clock: Clock): Int? {
+      val agePeriod = dob?.let { Period.between(dob, LocalDate.now(clock)) }
+      return agePeriod?.years
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/config/ClockConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/config/ClockConfiguration.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.assessments.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class ClockConfiguration {
+  @Bean
+  fun clock(): Clock? {
+    return Clock.systemDefaultZone()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/assessments/services/AssessmentService.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityOffen
 import uk.gov.justice.digital.assessments.services.dto.ExternalSource
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import uk.gov.justice.digital.assessments.utils.AssessmentUtils
+import java.time.Clock
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -39,7 +40,8 @@ class AssessmentService(
   private val episodeService: EpisodeService,
   private val offenderService: OffenderService,
   private val auditService: AuditService,
-  private val telemetryService: TelemetryService
+  private val telemetryService: TelemetryService,
+  private val clock: Clock
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -90,7 +92,7 @@ class AssessmentService(
 
   fun getAssessmentSubject(assessmentUuid: UUID): AssessmentSubjectDto {
     val assessment = getAssessmentByUuid(assessmentUuid)
-    return AssessmentSubjectDto.from(assessment.subject)
+    return AssessmentSubjectDto.from(assessment.subject, clock)
       ?: throw EntityNotFoundException("No subject found for $assessmentUuid")
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/api/AssessmentSubjectDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/api/AssessmentSubjectDtoTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.assessments.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.assessments.jpa.entities.assessments.SubjectEntity
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.UUID
+
+class AssessmentSubjectDtoTest {
+
+  @Test
+  fun `builds valid Assessment Subject DTO with calculated age`() {
+
+    val clock = Clock.fixed(Instant.parse("2022-03-06T12:18:05Z"), ZoneId.of("Europe/London"))
+
+    val subjectEntity = SubjectEntity(
+      1,
+      UUID.randomUUID(),
+      "name",
+      12345,
+      "pnc",
+      "crn",
+      LocalDate.of(2001, 8, 1),
+      "Male",
+      LocalDateTime.of(2020, 8, 1, 8, 0)
+    )
+
+    val assessmentSubjectDto = AssessmentSubjectDto.from(subjectEntity, clock)
+
+    assertThat(assessmentSubjectDto?.dob).isEqualTo(subjectEntity.dateOfBirth)
+    assertThat(assessmentSubjectDto?.age).isEqualTo(20)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/controller/AssessmentControllerTest.kt
@@ -48,7 +48,6 @@ class AssessmentControllerTest : IntegrationTest() {
 
       assertThat(subject.name).isEqualTo("John Smith")
       assertThat(subject.dob).isEqualTo("2001-01-01")
-      assertThat(subject.age).isEqualTo(21)
       assertThat(subject.crn).isEqualTo("X1346")
       assertThat(subject.pnc).isEqualTo("dummy-pnc")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceCreateTest.kt
@@ -29,8 +29,11 @@ import uk.gov.justice.digital.assessments.services.TelemetryEventType.ASSESSMENT
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
 import uk.gov.justice.digital.assessments.services.exceptions.ExternalApiForbiddenException
 import uk.gov.justice.digital.assessments.utils.RequestData
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -44,6 +47,7 @@ class AssessmentServiceCreateTest {
   private val offenderService: OffenderService = mockk()
   private val auditService: AuditService = mockk()
   private val telemetryService: TelemetryService = mockk()
+  private val clock: Clock = Clock.fixed(Instant.now(), ZoneId.of("Europe/London"))
 
   private val assessmentsService = AssessmentService(
     assessmentRepository,
@@ -53,7 +57,8 @@ class AssessmentServiceCreateTest {
     episodeService,
     offenderService,
     auditService,
-    telemetryService
+    telemetryService,
+    clock
   )
 
   private val assessmentUuid = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/assessments/services/AssessmentServiceTest.kt
@@ -28,8 +28,11 @@ import uk.gov.justice.digital.assessments.jpa.repositories.assessments.SubjectRe
 import uk.gov.justice.digital.assessments.restclient.audit.AuditType
 import uk.gov.justice.digital.assessments.restclient.communityapi.CommunityOffenderDto
 import uk.gov.justice.digital.assessments.services.exceptions.EntityNotFoundException
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -43,6 +46,7 @@ class AssessmentServiceTest {
   private val offenderService: OffenderService = mockk()
   private val auditService: AuditService = mockk()
   private val telemetryService: TelemetryService = mockk()
+  private val clock: Clock = Clock.fixed(Instant.now(), ZoneId.of("Europe/London"))
 
   private val assessmentsService = AssessmentService(
     assessmentRepository,
@@ -52,7 +56,8 @@ class AssessmentServiceTest {
     episodeService,
     offenderService,
     auditService,
-    telemetryService
+    telemetryService,
+    clock
   )
 
   private val assessmentUuid = UUID.randomUUID()


### PR DESCRIPTION
fix a broken test which has a fixed age value instead of relative by introducing Clock to mock out for age calculations in tests