### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6
+  hmpps: ministryofjustice/hmpps@7
 
 parameters:
   alerts-slack-channel:
@@ -13,7 +13,10 @@ executors:
     docker:
       - image: cimg/openjdk:17.0
         environment:
-          _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false
+          _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2
+            -XX:ParallelGCThreads=2
+            -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
+            -Dorg.gradle.daemon=false
           DATABASE_USERNAME: postgres
       - image: cimg/redis:7.0.11
         environment:
@@ -35,7 +38,8 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: ./gradlew -Dorg.gradle.jvmargs="--illegal-access=permit" -Dkotlin.daemon.jvm.options="--illegal-access=permit" check
+          command: ./gradlew -Dorg.gradle.jvmargs="--illegal-access=permit"
+            -Dkotlin.daemon.jvm.options="--illegal-access=permit" check
       - save_cache:
           paths:
             - ~/.gradle

--- a/helm_deploy/hmpps-assessments-api/Chart.yaml
+++ b/helm_deploy/hmpps-assessments-api/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-assessments-api/values.yaml
+++ b/helm_deploy/hmpps-assessments-api/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-assessments-api
 
@@ -6,14 +5,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-assessments-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
     v1_2_enabled: true
     v0_47_enabled: false
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-assessments-api-cert
     contextColour: green
 
@@ -53,131 +52,124 @@ generic-service:
       SPRING_DATA_REDIS_PASSWORD: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
-    # from https://my.pingdom.com/probes/ipv4
-    pingdom-1: "5.172.196.188"
-    pingdom-2: "13.232.220.164"
-    pingdom-3: "23.22.2.46"
-    pingdom-4: "23.83.129.219"
-    pingdom-5: "23.92.127.2"
-    pingdom-6: "23.106.37.99"
-    pingdom-7: "23.111.152.74"
-    pingdom-8: "23.111.159.174"
-    pingdom-9: "23.238.193.202"
-    pingdom-10: "37.252.231.50"
-    pingdom-11: "43.225.198.122"
-    pingdom-12: "43.229.84.12"
-    pingdom-13: "46.20.45.18"
-    pingdom-14: "46.246.122.10"
-    pingdom-15: "50.2.185.66"
-    pingdom-16: "50.16.153.186"
-    pingdom-17: "52.0.204.16"
-    pingdom-18: "52.24.42.103"
-    pingdom-19: "52.48.244.35"
-    pingdom-20: "52.52.34.158"
-    pingdom-21: "52.52.95.213"
-    pingdom-22: "52.52.118.192"
-    pingdom-23: "52.57.132.90"
-    pingdom-24: "52.59.46.112"
-    pingdom-25: "52.59.147.246"
-    pingdom-26: "52.62.12.49"
-    pingdom-27: "52.63.142.2"
-    pingdom-28: "52.63.164.147"
-    pingdom-29: "52.63.167.55"
-    pingdom-30: "52.67.148.55"
-    pingdom-31: "52.73.209.122"
-    pingdom-32: "52.89.43.70"
-    pingdom-33: "52.194.115.181"
-    pingdom-34: "52.197.31.124"
-    pingdom-35: "52.197.224.235"
-    pingdom-36: "52.198.25.184"
-    pingdom-37: "52.201.3.199"
-    pingdom-38: "52.209.34.226"
-    pingdom-39: "52.209.186.226"
-    pingdom-40: "52.210.232.124"
-    pingdom-41: "54.68.48.199"
-    pingdom-42: "54.70.202.58"
-    pingdom-43: "54.94.206.111"
-    pingdom-44: "64.237.49.203"
-    pingdom-45: "64.237.55.3"
-    pingdom-46: "66.165.229.130"
-    pingdom-47: "66.165.233.234"
-    pingdom-48: "72.46.130.18"
-    pingdom-49: "72.46.131.10"
-    pingdom-50: "76.72.167.154"
-    pingdom-51: "76.72.172.208"
-    pingdom-52: "76.164.234.106"
-    pingdom-53: "76.164.234.130"
-    pingdom-54: "82.103.136.16"
-    pingdom-55: "82.103.139.165"
-    pingdom-56: "82.103.145.126"
-    pingdom-57: "85.195.116.134"
-    pingdom-58: "89.163.146.247"
-    pingdom-59: "89.163.242.206"
-    pingdom-60: "94.75.211.73"
-    pingdom-61: "94.75.211.74"
-    pingdom-62: "94.247.174.83"
-    pingdom-63: "96.47.225.18"
-    pingdom-64: "103.10.197.10"
-    pingdom-65: "103.47.211.210"
-    pingdom-66: "104.129.24.154"
-    pingdom-67: "104.129.30.18"
-    pingdom-68: "107.182.234.77"
-    pingdom-69: "148.72.170.233"
-    pingdom-70: "148.72.171.17"
-    pingdom-71: "151.106.52.134"
-    pingdom-72: "159.122.168.9"
-    pingdom-73: "162.208.48.94"
-    pingdom-74: "162.218.67.34"
-    pingdom-75: "162.253.128.178"
-    pingdom-76: "168.1.203.46"
-    pingdom-77: "169.51.2.18"
-    pingdom-78: "169.54.70.214"
-    pingdom-79: "169.56.174.151"
-    pingdom-80: "172.241.112.86"
-    pingdom-81: "173.248.147.18"
-    pingdom-82: "173.254.206.242"
-    pingdom-83: "174.34.156.130"
-    pingdom-84: "175.45.132.20"
-    pingdom-85: "178.162.206.244"
-    pingdom-86: "178.255.152.2"
-    pingdom-87: "178.255.153.2"
-    pingdom-88: "179.50.12.212"
-    pingdom-89: "184.75.208.210"
-    pingdom-90: "184.75.209.18"
-    pingdom-91: "184.75.210.90"
-    pingdom-92: "184.75.210.226"
-    pingdom-93: "184.75.214.66"
-    pingdom-94: "184.75.214.98"
-    pingdom-95: "185.39.146.214"
-    pingdom-96: "185.39.146.215"
-    pingdom-97: "185.70.76.23"
-    pingdom-98: "185.93.3.65"
-    pingdom-99: "185.136.156.82"
-    pingdom-100: "185.152.65.167"
-    pingdom-101: "185.180.12.65"
-    pingdom-102: "185.246.208.82"
-    pingdom-103: "188.172.252.34"
-    pingdom-104: "190.120.230.7"
-    pingdom-105: "196.240.207.18"
-    pingdom-106: "196.244.191.18"
-    pingdom-107: "196.245.151.42"
-    pingdom-108: "199.87.228.66"
-    pingdom-109: "200.58.101.248"
-    pingdom-110: "201.33.21.5"
-    pingdom-111: "207.244.80.239"
-    pingdom-112: "209.58.139.193"
-    pingdom-113: "209.58.139.194"
-    pingdom-114: "209.95.50.14"
-    pingdom-115: "212.78.83.12"
-    pingdom-116: "212.78.83.16"
+    pingdom-1: 5.172.196.188/32
+    pingdom-2: 13.232.220.164/32
+    pingdom-3: 23.22.2.46/32
+    pingdom-4: 23.83.129.219/32
+    pingdom-5: 23.92.127.2/32
+    pingdom-6: 23.106.37.99/32
+    pingdom-7: 23.111.152.74/32
+    pingdom-8: 23.111.159.174/32
+    pingdom-9: 23.238.193.202/32
+    pingdom-10: 37.252.231.50/32
+    pingdom-11: 43.225.198.122/32
+    pingdom-12: 43.229.84.12/32
+    pingdom-13: 46.20.45.18/32
+    pingdom-14: 46.246.122.10/32
+    pingdom-15: 50.2.185.66/32
+    pingdom-16: 50.16.153.186/32
+    pingdom-17: 52.0.204.16/32
+    pingdom-18: 52.24.42.103/32
+    pingdom-19: 52.48.244.35/32
+    pingdom-20: 52.52.34.158/32
+    pingdom-21: 52.52.95.213/32
+    pingdom-22: 52.52.118.192/32
+    pingdom-23: 52.57.132.90/32
+    pingdom-24: 52.59.46.112/32
+    pingdom-25: 52.59.147.246/32
+    pingdom-26: 52.62.12.49/32
+    pingdom-27: 52.63.142.2/32
+    pingdom-28: 52.63.164.147/32
+    pingdom-29: 52.63.167.55/32
+    pingdom-30: 52.67.148.55/32
+    pingdom-31: 52.73.209.122/32
+    pingdom-32: 52.89.43.70/32
+    pingdom-33: 52.194.115.181/32
+    pingdom-34: 52.197.31.124/32
+    pingdom-35: 52.197.224.235/32
+    pingdom-36: 52.198.25.184/32
+    pingdom-37: 52.201.3.199/32
+    pingdom-38: 52.209.34.226/32
+    pingdom-39: 52.209.186.226/32
+    pingdom-40: 52.210.232.124/32
+    pingdom-41: 54.68.48.199/32
+    pingdom-42: 54.70.202.58/32
+    pingdom-43: 54.94.206.111/32
+    pingdom-44: 64.237.49.203/32
+    pingdom-45: 64.237.55.3/32
+    pingdom-46: 66.165.229.130/32
+    pingdom-47: 66.165.233.234/32
+    pingdom-48: 72.46.130.18/32
+    pingdom-49: 72.46.131.10/32
+    pingdom-50: 76.72.167.154/32
+    pingdom-51: 76.72.172.208/32
+    pingdom-52: 76.164.234.106/32
+    pingdom-53: 76.164.234.130/32
+    pingdom-54: 82.103.136.16/32
+    pingdom-55: 82.103.139.165/32
+    pingdom-56: 82.103.145.126/32
+    pingdom-57: 85.195.116.134/32
+    pingdom-58: 89.163.146.247/32
+    pingdom-59: 89.163.242.206/32
+    pingdom-60: 94.75.211.73/32
+    pingdom-61: 94.75.211.74/32
+    pingdom-62: 94.247.174.83/32
+    pingdom-63: 96.47.225.18/32
+    pingdom-64: 103.10.197.10/32
+    pingdom-65: 103.47.211.210/32
+    pingdom-66: 104.129.24.154/32
+    pingdom-67: 104.129.30.18/32
+    pingdom-68: 107.182.234.77/32
+    pingdom-69: 148.72.170.233/32
+    pingdom-70: 148.72.171.17/32
+    pingdom-71: 151.106.52.134/32
+    pingdom-72: 159.122.168.9/32
+    pingdom-73: 162.208.48.94/32
+    pingdom-74: 162.218.67.34/32
+    pingdom-75: 162.253.128.178/32
+    pingdom-76: 168.1.203.46/32
+    pingdom-77: 169.51.2.18/32
+    pingdom-78: 169.54.70.214/32
+    pingdom-79: 169.56.174.151/32
+    pingdom-80: 172.241.112.86/32
+    pingdom-81: 173.248.147.18/32
+    pingdom-82: 173.254.206.242/32
+    pingdom-83: 174.34.156.130/32
+    pingdom-84: 175.45.132.20/32
+    pingdom-85: 178.162.206.244/32
+    pingdom-86: 178.255.152.2/32
+    pingdom-87: 178.255.153.2/32
+    pingdom-88: 179.50.12.212/32
+    pingdom-89: 184.75.208.210/32
+    pingdom-90: 184.75.209.18/32
+    pingdom-91: 184.75.210.90/32
+    pingdom-92: 184.75.210.226/32
+    pingdom-93: 184.75.214.66/32
+    pingdom-94: 184.75.214.98/32
+    pingdom-95: 185.39.146.214/32
+    pingdom-96: 185.39.146.215/32
+    pingdom-97: 185.70.76.23/32
+    pingdom-98: 185.93.3.65/32
+    pingdom-99: 185.136.156.82/32
+    pingdom-100: 185.152.65.167/32
+    pingdom-101: 185.180.12.65/32
+    pingdom-102: 185.246.208.82/32
+    pingdom-103: 188.172.252.34/32
+    pingdom-104: 190.120.230.7/32
+    pingdom-105: 196.240.207.18/32
+    pingdom-106: 196.244.191.18/32
+    pingdom-107: 196.245.151.42/32
+    pingdom-108: 199.87.228.66/32
+    pingdom-109: 200.58.101.248/32
+    pingdom-110: 201.33.21.5/32
+    pingdom-111: 207.244.80.239/32
+    pingdom-112: 209.58.139.193/32
+    pingdom-113: 209.58.139.194/32
+    pingdom-114: 209.95.50.14/32
+    pingdom-115: 212.78.83.12/32
+    pingdom-116: 212.78.83.16/32
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   enabled: false


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-assessments-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `124 => 116 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
