### PR TITLE
Update Wiremock dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
   testImplementation("com.ninja-squad:springmockk:4.0.2")
   testImplementation("io.jsonwebtoken:jjwt-impl:0.12.3")
   testImplementation("io.jsonwebtoken:jjwt-jackson:0.12.3")
-  testImplementation("com.github.tomakehurst:wiremock-jre8-standalone:3.0.1")
+  testImplementation("org.wiremock:wiremock-standalone:3.4.1")
 }
 repositories {
   mavenCentral()


### PR DESCRIPTION
Looks like the [location of the repository changed](https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock-jre8-standalone), updating to ensure we continue to be notified of updates by Renovate