### PR TITLE
ARN-2041 - Remove dev context from Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ workflows:
           env: "dev"
           context:
             - hmpps-common-vars
-            - hmpps-assessments-dev-live
           filters:
             branches:
               only:


### PR DESCRIPTION
This is not required and will default to config from  environment variables